### PR TITLE
Fix manifold bet profit calculation

### DIFF
--- a/prediction_market_agent_tooling/markets/data_models.py
+++ b/prediction_market_agent_tooling/markets/data_models.py
@@ -279,9 +279,9 @@ class ManifoldBet(BaseModel):
 
     def get_resolved_boolean_outcome(self) -> bool:
         outcome = Resolution(self.outcome)
-        if self.outcome == Resolution.YES:
+        if outcome == Resolution.YES:
             return True
-        elif self.outcome == Resolution.NO:
+        elif outcome == Resolution.NO:
             return False
         else:
             should_not_happen(f"Unexpected bet outcome string, '{outcome.value}'.")

--- a/prediction_market_agent_tooling/markets/data_models.py
+++ b/prediction_market_agent_tooling/markets/data_models.py
@@ -197,7 +197,7 @@ class ManifoldMarket(BaseModel):
     def is_resolved_non_cancelled(self) -> bool:
         return (
             self.isResolved
-            and self.resolutionTime
+            and self.resolutionTime is not None
             and self.get_resolution_enum() != Resolution.CANCEL
         )
 

--- a/prediction_market_agent_tooling/markets/data_models.py
+++ b/prediction_market_agent_tooling/markets/data_models.py
@@ -235,6 +235,9 @@ class ManifoldBetFees(BaseModel):
     liquidityFee: Decimal
     creatorFee: Decimal
 
+    def get_total(self) -> Decimal:
+        return sum([self.platformFee, self.liquidityFee, self.creatorFee])
+
 
 class ManifoldBet(BaseModel):
     """
@@ -256,6 +259,19 @@ class ManifoldBet(BaseModel):
     fills: t.Optional[list[ManifoldBetFills]] = None
     createdTime: datetime
     outcome: str
+
+    def get_profit(self, market_outcome: bool) -> ProfitAmount:
+        outcome_bool = self.outcome == "YES"
+        profit = (
+            self.shares - self.amount
+            if outcome_bool == market_outcome
+            else -self.amount
+        )
+        profit -= self.fees.get_total()
+        return ProfitAmount(
+            amount=profit,
+            currency=Currency.Mana,
+        )
 
 
 class ManifoldContractMetric(BaseModel):

--- a/prediction_market_agent_tooling/markets/data_models.py
+++ b/prediction_market_agent_tooling/markets/data_models.py
@@ -236,7 +236,7 @@ class ManifoldBetFees(BaseModel):
     creatorFee: Decimal
 
     def get_total(self) -> Decimal:
-        return sum([self.platformFee, self.liquidityFee, self.creatorFee])
+        return Decimal(sum([self.platformFee, self.liquidityFee, self.creatorFee]))
 
 
 class ManifoldBet(BaseModel):

--- a/prediction_market_agent_tooling/markets/data_models.py
+++ b/prediction_market_agent_tooling/markets/data_models.py
@@ -156,7 +156,7 @@ class ManifoldMarket(BaseModel):
     isResolved: bool
     resolution: t.Optional[str] = None
     resolutionTime: t.Optional[datetime] = None
-    lastBetTime: datetime
+    lastBetTime: t.Optional[datetime] = None
     lastCommentTime: t.Optional[datetime] = None
     lastUpdatedTime: datetime
     mechanism: str

--- a/prediction_market_agent_tooling/markets/manifold.py
+++ b/prediction_market_agent_tooling/markets/manifold.py
@@ -12,6 +12,7 @@ from prediction_market_agent_tooling.markets.data_models import (
     ManifoldContractMetric,
     ManifoldMarket,
     ManifoldUser,
+    Resolution,
     ResolvedBet,
 )
 
@@ -112,21 +113,21 @@ def get_resolved_manifold_bets(
     bets = [b for b in bets if b.createdTime >= start_time]
     if end_time:
         bets = [b for b in bets if b.createdTime < end_time]
-    bets = [b for b in bets if get_manifold_market(b.contractId).isResolved]
+    bets = [
+        b for b in bets if get_manifold_market(b.contractId).is_resolved_non_cancelled()
+    ]
     return bets
 
 
 def manifold_to_generic_resolved_bet(bet: ManifoldBet) -> ResolvedBet:
     market = get_manifold_market(bet.contractId)
-    if not market.isResolved:
+    if not market.is_resolved_non_cancelled():
         raise ValueError(f"Market {market.id} is not resolved.")
-    if not market.resolutionTime:
-        raise ValueError(f"Market {market.id} has no resolution time.")
 
-    market_outcome = market.resolution == "YES"
+    market_outcome = market.get_resolution_enum() == Resolution.YES
     return ResolvedBet(
         amount=BetAmount(amount=bet.amount, currency=Currency.Mana),
-        outcome=bet.outcome == "YES",
+        outcome=bet.get_resolved_boolean_outcome(),
         created_time=bet.createdTime,
         market_question=market.question,
         market_outcome=market_outcome,

--- a/prediction_market_agent_tooling/markets/manifold.py
+++ b/prediction_market_agent_tooling/markets/manifold.py
@@ -12,7 +12,6 @@ from prediction_market_agent_tooling.markets.data_models import (
     ManifoldContractMetric,
     ManifoldMarket,
     ManifoldUser,
-    ProfitAmount,
     ResolvedBet,
 )
 
@@ -124,19 +123,15 @@ def manifold_to_generic_resolved_bet(bet: ManifoldBet) -> ResolvedBet:
     if not market.resolutionTime:
         raise ValueError(f"Market {market.id} has no resolution time.")
 
-    # Get the profit for this bet from the corresponding position
-    positions = get_market_positions(market.id, bet.userId)
-    bet_position = next(p for p in positions if p.contractId == bet.contractId)
-    profit = bet_position.profit
-
+    market_outcome = market.resolution == "YES"
     return ResolvedBet(
         amount=BetAmount(amount=bet.amount, currency=Currency.Mana),
         outcome=bet.outcome == "YES",
         created_time=bet.createdTime,
         market_question=market.question,
-        market_outcome=market.resolution == "YES",
+        market_outcome=market_outcome,
         resolved_time=market.resolutionTime,
-        profit=ProfitAmount(amount=profit, currency=Currency.Mana),
+        profit=bet.get_profit(market_outcome=market_outcome),
     )
 
 

--- a/prediction_market_agent_tooling/markets/manifold.py
+++ b/prediction_market_agent_tooling/markets/manifold.py
@@ -123,6 +123,8 @@ def manifold_to_generic_resolved_bet(bet: ManifoldBet) -> ResolvedBet:
     market = get_manifold_market(bet.contractId)
     if not market.is_resolved_non_cancelled():
         raise ValueError(f"Market {market.id} is not resolved.")
+    if not market.resolutionTime:
+        raise ValueError(f"Market {market.id} has no resolution time.")
 
     market_outcome = market.get_resolution_enum() == Resolution.YES
     return ResolvedBet(


### PR DESCRIPTION
Fixes a bug in manifold monitoring code where per-bet profit was calculated based on a user's market 'position'. However, this was incorrect, as a user can have multiple bets on a given market, but only one position. This meant:

1. Profit/loss was being double-counted in the case where a user has >1 bet on a given market
2. If an agent has `start_time`, `s` and has placed at least one bet on a given market after `s`, its profit for that market took into account bets also made before `s`

Result, before:
<img width="1278" alt="Screenshot 2024-02-19 at 12 44 37" src="https://github.com/gnosis/prediction-market-agent-tooling/assets/56087052/0c1b4335-b741-4d55-852e-7597fb742279">

After:
<img width="1262" alt="Screenshot 2024-02-19 at 12 47 02" src="https://github.com/gnosis/prediction-market-agent-tooling/assets/56087052/810e8af3-30bb-492d-8f0f-4f69a7c34959">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality to calculate total fees and profits for bets in the prediction market tool.

- **Refactor**
	- Improved profit calculation logic for more accurate outcomes.
	- Streamlined the process of assigning market outcomes to bets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->