### PR TITLE
Fix benchmark for cancelled markets

### DIFF
--- a/prediction_market_agent_tooling/benchmark/benchmark.py
+++ b/prediction_market_agent_tooling/benchmark/benchmark.py
@@ -38,6 +38,10 @@ class Benchmarker:
             self.registered_agents
         ):
             raise ValueError("Agents must have unique names")
+        if any(m.is_cancelled for m in markets):
+            raise ValueError(
+                "Cancelled markets shoudln't be used in the benchmark, please filter them out."
+            )
 
         # Predictions
         self.cache_path = cache_path

--- a/prediction_market_agent_tooling/benchmark/benchmark.py
+++ b/prediction_market_agent_tooling/benchmark/benchmark.py
@@ -40,7 +40,7 @@ class Benchmarker:
             raise ValueError("Agents must have unique names")
         if any(m.is_cancelled for m in markets):
             raise ValueError(
-                "Cancelled markets shoudln't be used in the benchmark, please filter them out."
+                "Cancelled markets shouldn't be used in the benchmark, please filter them out."
             )
 
         # Predictions

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -180,10 +180,7 @@ def test_market_probable_resolution() -> None:
             created_time=datetime.datetime.now(),
             resolution=CancelableMarketResolution.CANCEL,
         ).probable_resolution
-    assert (
-        "Unknown resolution `cancel`, if it is `cancel`, you should first filter out cancelled markets."
-        in str(e)
-    )
+    assert "Unknown resolution" in str(e)
     assert (
         Market(
             source=MarketSource.MANIFOLD,

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -164,7 +164,7 @@ def test_benchmarker_cancelled_markets() -> None:
             agents=[],
         )
     assert (
-        "Cancelled markets shoudln't be used in the benchmark, please filter them out."
+        "Cancelled markets shouldn't be used in the benchmark, please filter them out."
         in str(e)
     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced a new check to exclude cancelled markets from benchmarks.
    - Added `CancelableMarketResolution` enum to improve handling of market resolutions and cancellations.
- **Tests**
    - New test cases added for benchmarking functionality, focusing on market resolutions and cancellations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->