### PR TITLE
Fix monitor_app

### DIFF
--- a/prediction_market_agent_tooling/benchmark/utils.py
+++ b/prediction_market_agent_tooling/benchmark/utils.py
@@ -36,6 +36,7 @@ class CancelableMarketResolution(str, Enum):
     YES = "yes"
     NO = "no"
     CANCEL = "cancel"
+    MKT = "mkt"
 
 
 class Market(BaseModel):
@@ -65,6 +66,13 @@ class Market(BaseModel):
     @property
     def is_resolved(self) -> bool:
         return self.resolution is not None
+
+    @property
+    def has_successful_resolution(self) -> bool:
+        return self.resolution not in [
+            CancelableMarketResolution.CANCEL,
+            CancelableMarketResolution.MKT,
+        ]
 
     @property
     def is_cancelled(self) -> bool:

--- a/prediction_market_agent_tooling/monitor/monitor.py
+++ b/prediction_market_agent_tooling/monitor/monitor.py
@@ -8,7 +8,10 @@ import pandas as pd
 import streamlit as st
 from pydantic import BaseModel
 
-from prediction_market_agent_tooling.benchmark.utils import Market
+from prediction_market_agent_tooling.benchmark.utils import (
+    CancelableMarketResolution,
+    Market,
+)
 from prediction_market_agent_tooling.markets.data_models import ResolvedBet
 from prediction_market_agent_tooling.tools.utils import should_not_happen
 
@@ -80,10 +83,10 @@ def monitor_market(open_markets: list[Market], resolved_markets: list[Market]) -
             [
                 (
                     1
-                    if m.resolution == "YES"
+                    if m.resolution == CancelableMarketResolution.YES
                     else (
                         0
-                        if m.resolution == "NO"
+                        if m.resolution == CancelableMarketResolution.NO
                         else should_not_happen(f"Unexpected resolution: {m.resolution}")
                     )
                 )
@@ -126,10 +129,10 @@ def monitor_market(open_markets: list[Market], resolved_markets: list[Market]) -
         [
             (
                 1
-                if m.resolution == "YES"
+                if m.resolution == CancelableMarketResolution.YES
                 else (
                     0
-                    if m.resolution == "NO"
+                    if m.resolution == CancelableMarketResolution.NO
                     else should_not_happen(f"Unexpected resolution: {m.resolution}")
                 )
             )

--- a/prediction_market_agent_tooling/monitor/monitor_app.py
+++ b/prediction_market_agent_tooling/monitor/monitor_app.py
@@ -53,7 +53,7 @@ def monitor_app() -> None:
     resolved_markets = [
         m
         for m in get_manifold_markets_dated(oldest_date=start_time, filter_="resolved")
-        if m.resolution not in ("CANCEL", "MKT")
+        if m.has_successful_resolution
     ]
     monitor_market(open_markets=open_markets, resolved_markets=resolved_markets)
 


### PR DESCRIPTION
Fix code in market monitoring. `streamlit run examples/monitor/monitor.py` was throwing:
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Market
resolution
  Input should be 'yes', 'no' or 'cancel' [type=enum, input_value='mkt', input_type=str]
```