### PR TITLE
Split get markets and get resolved markets

### DIFF
--- a/prediction_market_agent_tooling/markets/manifold/api.py
+++ b/prediction_market_agent_tooling/markets/manifold/api.py
@@ -101,7 +101,7 @@ def get_manifold_market(market_id: str) -> ManifoldMarket:
     return ManifoldMarket.model_validate(response.json())
 
 
-def get_resolved_manifold_bets(
+def get_manifold_bets(
     user_id: str,
     start_time: datetime,
     end_time: t.Optional[datetime],
@@ -115,6 +115,15 @@ def get_resolved_manifold_bets(
     bets = [b for b in bets if b.createdTime >= start_time]
     if end_time:
         bets = [b for b in bets if b.createdTime < end_time]
+    return bets
+
+
+def get_resolved_manifold_bets(
+    user_id: str,
+    start_time: datetime,
+    end_time: t.Optional[datetime],
+) -> list[ManifoldBet]:
+    bets = get_manifold_bets(user_id, start_time, end_time)
     bets = [
         b for b in bets if get_manifold_market(b.contractId).is_resolved_non_cancelled()
     ]

--- a/prediction_market_agent_tooling/markets/omen/omen.py
+++ b/prediction_market_agent_tooling/markets/omen/omen.py
@@ -706,7 +706,7 @@ def to_int_timestamp(dt: datetime) -> int:
     return int(dt.timestamp())
 
 
-def get_bets(
+def get_omen_bets(
     better_address: ChecksumAddress,
     start_time: datetime,
     end_time: t.Optional[datetime],
@@ -745,6 +745,19 @@ def get_bets(
         all_bets.extend(OmenBet.model_validate(bet) for bet in bets)
 
     return all_bets
+
+
+def get_resolved_omen_bets(
+    better_address: ChecksumAddress,
+    start_time: datetime,
+    end_time: t.Optional[datetime],
+) -> list[OmenBet]:
+    bets = get_omen_bets(
+        better_address=better_address,
+        start_time=start_time,
+        end_time=end_time,
+    )
+    return [b for b in bets if b.fpmm.is_resolved]
 
 
 def omen_realitio_ask_question_tx(

--- a/prediction_market_agent_tooling/monitor/markets/manifold.py
+++ b/prediction_market_agent_tooling/monitor/markets/manifold.py
@@ -19,7 +19,7 @@ class DeployedManifoldAgent(DeployedAgent):
         manifold_bets = get_resolved_manifold_bets(
             user_id=self.manifold_user_id,
             start_time=self.start_time,
-            end_time=None,
+            end_time=self.end_time,
         )
         return [manifold_to_generic_resolved_bet(b) for b in manifold_bets]
 

--- a/prediction_market_agent_tooling/monitor/markets/omen.py
+++ b/prediction_market_agent_tooling/monitor/markets/omen.py
@@ -8,8 +8,8 @@ from prediction_market_agent_tooling.config import APIKeys
 from prediction_market_agent_tooling.deploy.constants import MARKET_TYPE_KEY
 from prediction_market_agent_tooling.gtypes import ChecksumAddress
 from prediction_market_agent_tooling.markets.data_models import ResolvedBet
-from prediction_market_agent_tooling.markets.omen.omen import get_resolved_omen_bets
 from prediction_market_agent_tooling.markets.markets import MarketType
+from prediction_market_agent_tooling.markets.omen.omen import get_resolved_omen_bets
 from prediction_market_agent_tooling.monitor.monitor import (
     DeployedAgent,
     MonitorSettings,

--- a/prediction_market_agent_tooling/monitor/markets/omen.py
+++ b/prediction_market_agent_tooling/monitor/markets/omen.py
@@ -4,7 +4,7 @@ from web3 import Web3
 
 from prediction_market_agent_tooling.gtypes import ChecksumAddress
 from prediction_market_agent_tooling.markets.data_models import ResolvedBet
-from prediction_market_agent_tooling.markets.omen.omen import get_bets
+from prediction_market_agent_tooling.markets.omen.omen import get_resolved_omen_bets
 from prediction_market_agent_tooling.monitor.monitor import (
     DeployedAgent,
     MonitorSettings,
@@ -15,12 +15,12 @@ class DeployedOmenAgent(DeployedAgent):
     wallet_address: ChecksumAddress
 
     def get_resolved_bets(self) -> list[ResolvedBet]:
-        bets = get_bets(
+        bets = get_resolved_omen_bets(
             better_address=self.wallet_address,
             start_time=self.start_time,
-            end_time=None,
+            end_time=self.end_time,
         )
-        return [b.to_generic_resolved_bet() for b in bets if b.fpmm.is_resolved]
+        return [b.to_generic_resolved_bet() for b in bets]
 
     @staticmethod
     def from_monitor_settings(

--- a/prediction_market_agent_tooling/monitor/markets/omen.py
+++ b/prediction_market_agent_tooling/monitor/markets/omen.py
@@ -21,7 +21,7 @@ class DeployedOmenAgent(DeployedAgent):
 
     def get_resolved_bets(self) -> list[ResolvedBet]:
         bets = get_resolved_omen_bets(
-            better_address=self.wallet_address,
+            better_address=self.omen_public_key,
             start_time=self.start_time,
             end_time=self.end_time,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prediction-market-agent-tooling"
-version = "0.2.8"
+version = "0.3.0"
 description = "Tools to benchmark, deploy and monitor prediction market agents."
 authors = ["Gnosis"]
 readme = "README.md"

--- a/tests/markets/test_omen.py
+++ b/tests/markets/test_omen.py
@@ -10,8 +10,8 @@ from prediction_market_agent_tooling.markets.omen.omen import (
     OmenAgentMarket,
     binary_omen_buy_outcome_tx,
     binary_omen_sell_outcome_tx,
-    get_bets,
     get_market,
+    get_omen_bets,
     pick_binary_market,
 )
 from tests.utils import RUN_PAID_TESTS
@@ -60,7 +60,7 @@ def test_omen_buy_and_sell_outcome() -> None:
 
 def test_get_bets() -> None:
     AN_ADDRESS = Web3.to_checksum_address("0x3666DA333dAdD05083FEf9FF6dDEe588d26E4307")
-    bets = get_bets(
+    bets = get_omen_bets(
         better_address=AN_ADDRESS,
         start_time=datetime(2024, 2, 20),
         end_time=datetime(2024, 2, 21),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for better filtering of resolved bets in both Manifold and Omen markets.
- **Enhancements**
	- Improved the accuracy of resolved bets retrieval by adjusting the `end_time` parameter usage.
- **Refactor**
	- Renamed functions for clarity and consistency across Manifold and Omen market tooling.
- **Tests**
	- Updated test cases to align with the latest function naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->