### PR TITLE
Introduce Contract classes + use them

### DIFF
--- a/examples/replicate_markets/agent_example.py
+++ b/examples/replicate_markets/agent_example.py
@@ -9,12 +9,13 @@ from prediction_market_agent_tooling.benchmark.utils import MarketSource
 from prediction_market_agent_tooling.config import APIKeys
 from prediction_market_agent_tooling.deploy.agent import DeployableAgent, MarketType
 from prediction_market_agent_tooling.gtypes import xdai_type
-from prediction_market_agent_tooling.markets.omen.omen import (
-    omen_create_market_deposit_tx,
+from prediction_market_agent_tooling.markets.omen.omen_contracts import (
+    OmenCollateralTokenContract,
 )
 from prediction_market_agent_tooling.markets.omen.omen_replicate import (
     omen_replicate_from_tx,
 )
+from prediction_market_agent_tooling.tools.web3_utils import xdai_to_wei
 
 
 class ReplicateSettings(BaseSettings):
@@ -40,11 +41,13 @@ class DeployableReplicateToOmenAgent(DeployableAgent):
         deposit_funds_per_replication = xdai_type(
             initial_funds_per_market * settings.N_TO_REPLICATE
         )
+        deposit_funds_per_replication_wei = xdai_to_wei(deposit_funds_per_replication)
+        collateral_token_contract = OmenCollateralTokenContract()
 
         print(f"Replicating from {MarketSource.MANIFOLD}.")
         # Deposit enough of xDai for all N markets to be replicated, so we don't re-deposit in case of re-tries.
-        omen_create_market_deposit_tx(
-            deposit_funds_per_replication,
+        collateral_token_contract.deposit(
+            deposit_funds_per_replication_wei,
             keys.bet_from_address,
             keys.bet_from_private_key,
         )
@@ -59,8 +62,8 @@ class DeployableReplicateToOmenAgent(DeployableAgent):
         )
         print(f"Replicating from {MarketSource.POLYMARKET}.")
         # Deposit enough of xDai for all N markets to be replicated, so we don't re-deposit in case of re-tries.
-        omen_create_market_deposit_tx(
-            deposit_funds_per_replication,
+        collateral_token_contract.deposit(
+            deposit_funds_per_replication_wei,
             keys.bet_from_address,
             keys.bet_from_private_key,
         )

--- a/examples/replicate_markets/agent_example.py
+++ b/examples/replicate_markets/agent_example.py
@@ -9,13 +9,9 @@ from prediction_market_agent_tooling.benchmark.utils import MarketSource
 from prediction_market_agent_tooling.config import APIKeys
 from prediction_market_agent_tooling.deploy.agent import DeployableAgent, MarketType
 from prediction_market_agent_tooling.gtypes import xdai_type
-from prediction_market_agent_tooling.markets.omen.omen_contracts import (
-    OmenCollateralTokenContract,
-)
 from prediction_market_agent_tooling.markets.omen.omen_replicate import (
     omen_replicate_from_tx,
 )
-from prediction_market_agent_tooling.tools.web3_utils import xdai_to_wei
 
 
 class ReplicateSettings(BaseSettings):
@@ -38,19 +34,8 @@ class DeployableReplicateToOmenAgent(DeployableAgent):
             datetime.utcnow() + timedelta(days=settings.CLOSE_TIME_UP_TO_N_DAYS)
         ).replace(tzinfo=pytz.UTC)
         initial_funds_per_market = xdai_type(settings.INITIAL_FUNDS)
-        deposit_funds_per_replication = xdai_type(
-            initial_funds_per_market * settings.N_TO_REPLICATE
-        )
-        deposit_funds_per_replication_wei = xdai_to_wei(deposit_funds_per_replication)
-        collateral_token_contract = OmenCollateralTokenContract()
 
         print(f"Replicating from {MarketSource.MANIFOLD}.")
-        # Deposit enough of xDai for all N markets to be replicated, so we don't re-deposit in case of re-tries.
-        collateral_token_contract.deposit(
-            deposit_funds_per_replication_wei,
-            keys.bet_from_address,
-            keys.bet_from_private_key,
-        )
         omen_replicate_from_tx(
             market_source=MarketSource.MANIFOLD,
             n_to_replicate=settings.N_TO_REPLICATE,
@@ -61,12 +46,6 @@ class DeployableReplicateToOmenAgent(DeployableAgent):
             auto_deposit=False,
         )
         print(f"Replicating from {MarketSource.POLYMARKET}.")
-        # Deposit enough of xDai for all N markets to be replicated, so we don't re-deposit in case of re-tries.
-        collateral_token_contract.deposit(
-            deposit_funds_per_replication_wei,
-            keys.bet_from_address,
-            keys.bet_from_private_key,
-        )
         omen_replicate_from_tx(
             market_source=MarketSource.POLYMARKET,
             n_to_replicate=settings.N_TO_REPLICATE,

--- a/prediction_market_agent_tooling/gtypes.py
+++ b/prediction_market_agent_tooling/gtypes.py
@@ -13,7 +13,11 @@ from hexbytes import (  # noqa: F401  # Import for the sake of easy importing wi
 )
 from pydantic.types import SecretStr
 from pydantic.v1.types import SecretStr as SecretStrV1
-from web3.types import Wei
+from web3.types import (  # noqa: F401  # Import for the sake of easy importing with others from here.
+    TxParams,
+    TxReceipt,
+    Wei,
+)
 
 Wad = Wei  # Wei tends to be referred to as `wad` variable in contracts.
 USD = NewType(
@@ -27,6 +31,7 @@ OmenOutcomeToken = NewType("OmenOutcomeToken", int)
 Probability = NewType("Probability", float)
 Mana = NewType("Mana", Decimal)  # Manifold's "currency"
 DatetimeWithTimezone = NewType("DatetimeWithTimezone", datetime)
+ChainID = NewType("ChainID", int)
 
 
 def usd_type(amount: Union[str, int, float, Decimal]) -> USD:

--- a/prediction_market_agent_tooling/markets/omen/omen.py
+++ b/prediction_market_agent_tooling/markets/omen/omen.py
@@ -373,15 +373,9 @@ def omen_sell_outcome_tx(
     collateral_token = OmenCollateralTokenContract()
 
     # Verify, that markets uses conditional tokens that we expect.
-    markets_conditional_token_contract = OmenFixedProductMarketMakerContract(
-        address=market_contract.address
-    )
-    if (
-        markets_conditional_token_contract.conditionalTokens()
-        != conditional_token_contract.address
-    ):
+    if market_contract.conditionalTokens() != conditional_token_contract.address:
         raise ValueError(
-            f"Market {market.id} uses conditional token that we didn't expect, {markets_conditional_token_contract.conditionalTokens()} != {conditional_token_contract.address=}"
+            f"Market {market.id} uses conditional token that we didn't expect, {market_contract.conditionalTokens()} != {conditional_token_contract.address=}"
         )
 
     # Get the index of the outcome we want to buy.

--- a/prediction_market_agent_tooling/markets/omen/omen.py
+++ b/prediction_market_agent_tooling/markets/omen/omen.py
@@ -115,6 +115,11 @@ class OmenAgentMarket(AgentMarket):
             )
         ]
 
+    def get_contract(self) -> OmenFixedProductMarketMakerContract:
+        return OmenFixedProductMarketMakerContract(
+            address=self.market_maker_contract_address_checksummed
+        )
+
 
 _QUERY_GET_SINGLE_FIXED_PRODUCT_MARKET_MAKER = """
 query getFixedProductMarketMaker($id: String!) {
@@ -293,7 +298,7 @@ def omen_buy_outcome_tx(
     amount_wei = xdai_to_wei(amount)
     from_address_checksummed = Web3.to_checksum_address(from_address)
 
-    market_contract = OmenFixedProductMarketMakerContract.from_agent_market(market)
+    market_contract: OmenFixedProductMarketMakerContract = market.get_contract()
     collateral_token_contract = OmenCollateralTokenContract()
 
     # Get the index of the outcome we want to buy.
@@ -363,7 +368,7 @@ def omen_sell_outcome_tx(
     amount_wei = xdai_to_wei(amount)
     from_address_checksummed = Web3.to_checksum_address(from_address)
 
-    market_contract = OmenFixedProductMarketMakerContract.from_agent_market(market)
+    market_contract: OmenFixedProductMarketMakerContract = market.get_contract()
     conditional_token_contract = OmenConditionalTokenContract()
     collateral_token = OmenCollateralTokenContract()
 

--- a/prediction_market_agent_tooling/markets/omen/omen.py
+++ b/prediction_market_agent_tooling/markets/omen/omen.py
@@ -1,18 +1,45 @@
 import typing as t
+from datetime import datetime
 from decimal import Decimal
 
 import requests
 from web3 import Web3
 
 from prediction_market_agent_tooling.config import APIKeys
-from prediction_market_agent_tooling.gtypes import ChecksumAddress, xDai
+from prediction_market_agent_tooling.gtypes import (
+    ChecksumAddress,
+    HexAddress,
+    PrivateKey,
+    xDai,
+)
 from prediction_market_agent_tooling.markets.agent_market import (
     AgentMarket,
     FilterBy,
     SortBy,
 )
 from prediction_market_agent_tooling.markets.data_models import BetAmount, Currency
-from prediction_market_agent_tooling.markets.omen.data_models import OmenMarket
+from prediction_market_agent_tooling.markets.omen.data_models import (
+    OMEN_FALSE_OUTCOME,
+    OMEN_TRUE_OUTCOME,
+    OmenBet,
+    OmenMarket,
+)
+from prediction_market_agent_tooling.markets.omen.omen_contracts import (
+    OMEN_DEFAULT_MARKET_FEE,
+    Arbitrator,
+    OmenCollateralTokenContract,
+    OmenConditionalTokenContract,
+    OmenFixedProductMarketMakerContract,
+    OmenFixedProductMarketMakerFactoryContract,
+    OmenOracleContract,
+    OmenRealitioContract,
+)
+from prediction_market_agent_tooling.tools.utils import utcnow
+from prediction_market_agent_tooling.tools.web3_utils import (
+    add_fraction,
+    remove_fraction,
+    xdai_to_wei,
+)
 
 """
 Python API for Omen prediction market.
@@ -23,6 +50,7 @@ but to not use our own credits, seems we can use their api deployment directly: 
 
 OMEN_QUERY_BATCH_SIZE = 1000
 OMEN_DEFAULT_MARKET_FEE = 0.02  # 2% fee from the buying shares amount.
+THEGRAPH_QUERY_URL = "https://api.thegraph.com/subgraphs/name/protofire/omen-xdai"
 
 
 class OmenAgentMarket(AgentMarket):
@@ -87,44 +115,6 @@ class OmenAgentMarket(AgentMarket):
             )
         ]
 
-
-import typing as t
-from datetime import datetime
-
-import requests
-from web3 import Web3
-
-from prediction_market_agent_tooling.gtypes import (
-    ChecksumAddress,
-    HexAddress,
-    PrivateKey,
-    xDai,
-)
-from prediction_market_agent_tooling.markets.omen.data_models import (
-    OMEN_FALSE_OUTCOME,
-    OMEN_TRUE_OUTCOME,
-    OmenBet,
-    OmenMarket,
-)
-from prediction_market_agent_tooling.markets.omen.omen_contracts import (
-    OMEN_DEFAULT_MARKET_FEE,
-    Arbitrator,
-    OmenCollateralTokenContract,
-    OmenConditionalTokenContract,
-    OmenFixedProductMarketMakerContract,
-    OmenFixedProductMarketMakerFactoryContract,
-    OmenOracleContract,
-    OmenRealitioContract,
-)
-from prediction_market_agent_tooling.tools.utils import utcnow
-from prediction_market_agent_tooling.tools.web3_utils import (
-    add_fraction,
-    remove_fraction,
-    xdai_to_wei,
-)
-
-OMEN_QUERY_BATCH_SIZE = 1000
-THEGRAPH_QUERY_URL = "https://api.thegraph.com/subgraphs/name/protofire/omen-xdai"
 
 _QUERY_GET_SINGLE_FIXED_PRODUCT_MARKET_MAKER = """
 query getFixedProductMarketMaker($id: String!) {

--- a/prediction_market_agent_tooling/markets/omen/omen_contracts.py
+++ b/prediction_market_agent_tooling/markets/omen/omen_contracts.py
@@ -1,0 +1,392 @@
+import json
+import os
+import random
+import typing as t
+from datetime import datetime
+from enum import Enum
+
+from web3 import Web3
+
+from prediction_market_agent_tooling.gtypes import (
+    ABI,
+    ChecksumAddress,
+    HexAddress,
+    HexBytes,
+    OmenOutcomeToken,
+    PrivateKey,
+    TxParams,
+    TxReceipt,
+    Wei,
+    xdai_type,
+)
+from prediction_market_agent_tooling.markets.omen.omen import OmenAgentMarket
+from prediction_market_agent_tooling.tools.contract import (
+    ContractERC20OnGnosisChain,
+    ContractOnGnosisChain,
+    abi_field_validator,
+)
+from prediction_market_agent_tooling.tools.web3_utils import xdai_to_wei
+
+
+class OmenOracleContract(ContractOnGnosisChain):
+    # Contract ABI taken from https://gnosisscan.io/address/0xAB16D643bA051C11962DA645f74632d3130c81E2#code.
+    abi: ABI = abi_field_validator(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "../../abis/omen_oracle.abi.json",
+        )
+    )
+    address: ChecksumAddress = Web3.to_checksum_address(
+        "0xAB16D643bA051C11962DA645f74632d3130c81E2"
+    )
+
+    def realitio(self) -> ChecksumAddress:
+        realitio_address: ChecksumAddress = self.call("realitio")
+        return realitio_address
+
+    def conditionalTokens(self) -> ChecksumAddress:
+        realitio_address: ChecksumAddress = self.call("conditionalTokens")
+        return realitio_address
+
+
+class OmenConditionalTokenContract(ContractOnGnosisChain):
+    # Contract ABI taken from https://gnosisscan.io/address/0xCeAfDD6bc0bEF976fdCd1112955828E00543c0Ce#code.
+    abi: ABI = abi_field_validator(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "../../abis/omen_fpmm_conditionaltokens.abi.json",
+        )
+    )
+    address: ChecksumAddress = Web3.to_checksum_address(
+        "0xCeAfDD6bc0bEF976fdCd1112955828E00543c0Ce"
+    )
+
+    def getConditionId(
+        self,
+        question_id: HexBytes,
+        oracle_address: ChecksumAddress,
+        outcomes_slot_count: int,
+    ) -> HexBytes:
+        id_: HexBytes = self.call(
+            "getConditionId",
+            [oracle_address, question_id, outcomes_slot_count],
+        )
+        return id_
+
+    def getOutcomeSlotCount(
+        self,
+        condition_id: HexBytes,
+    ) -> int:
+        count: int = self.call(
+            "getOutcomeSlotCount",
+            [condition_id],
+        )
+        return count
+
+    def does_condition_exists(
+        self,
+        condition_id: HexBytes,
+    ) -> bool:
+        return self.getOutcomeSlotCount(condition_id) > 0
+
+    def setApprovalForAll(
+        self,
+        for_address: ChecksumAddress,
+        approve: bool,
+        from_address: ChecksumAddress,
+        from_private_key: PrivateKey,
+        tx_params: t.Optional[TxParams] = None,
+    ) -> TxReceipt:
+        return self.send(
+            from_address=from_address,
+            from_private_key=from_private_key,
+            function_name="setApprovalForAll",
+            function_params=[
+                for_address,
+                approve,
+            ],
+            tx_params=tx_params,
+        )
+
+    def prepareCondition(
+        self,
+        oracle_address: ChecksumAddress,
+        question_id: HexBytes,
+        outcomes_slot_count: int,
+        from_address: ChecksumAddress,
+        from_private_key: PrivateKey,
+        tx_params: t.Optional[TxParams] = None,
+    ) -> TxReceipt:
+        return self.send(
+            from_address=from_address,
+            from_private_key=from_private_key,
+            function_name="prepareCondition",
+            function_params=[
+                oracle_address,
+                question_id,
+                outcomes_slot_count,
+            ],
+            tx_params=tx_params,
+        )
+
+
+class OmenFixedProductMarketMakerContract(ContractOnGnosisChain):
+    # File content taken from https://github.com/protofire/omen-exchange/blob/master/app/src/abi/marketMaker.json.
+    abi: ABI = abi_field_validator(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), "../../abis/omen_fpmm.abi.json"
+        )
+    )
+
+    # ! Note: This doesn't have a fixed contract address, as this is something created by the `OmenFixedProductMarketMakerFactory`.
+    # Factory contract at https://gnosisscan.io/address/0x9083a2b699c0a4ad06f63580bde2635d26a3eef0.
+
+    @staticmethod
+    def from_agent_market(
+        market: OmenAgentMarket,
+    ) -> "OmenFixedProductMarketMakerContract":
+        return OmenFixedProductMarketMakerContract(
+            address=market.market_maker_contract_address_checksummed
+        )
+
+    def calcBuyAmount(
+        self,
+        investment_amount: Wei,
+        outcome_index: int,
+    ) -> OmenOutcomeToken:
+        """
+        Returns amount of shares we will get for the given outcome_index for the given investment amount.
+        """
+        calculated_shares: OmenOutcomeToken = self.call(
+            "calcBuyAmount",
+            [investment_amount, outcome_index],
+        )
+        return calculated_shares
+
+    def calcSellAmount(
+        self,
+        return_amount: Wei,
+        outcome_index: int,
+    ) -> OmenOutcomeToken:
+        """
+        Returns amount of shares we will sell for the requested wei.
+        """
+        calculated_shares: OmenOutcomeToken = self.call(
+            "calcSellAmount",
+            [return_amount, outcome_index],
+        )
+        return calculated_shares
+
+    def conditionalTokens(
+        self,
+    ) -> HexAddress:
+        address: HexAddress = self.call(
+            "conditionalTokens",
+        )
+        return address
+
+    def buy(
+        self,
+        amount_wei: Wei,
+        outcome_index: int,
+        min_outcome_tokens_to_buy: OmenOutcomeToken,
+        from_address: ChecksumAddress,
+        from_private_key: PrivateKey,
+        tx_params: t.Optional[TxParams] = None,
+    ) -> TxReceipt:
+        return self.send(
+            from_address=from_address,
+            from_private_key=from_private_key,
+            function_name="buy",
+            function_params=[
+                amount_wei,
+                outcome_index,
+                min_outcome_tokens_to_buy,
+            ],
+            tx_params=tx_params,
+        )
+
+    def sell(
+        self,
+        amount_wei: Wei,
+        outcome_index: int,
+        max_outcome_tokens_to_sell: OmenOutcomeToken,
+        from_address: ChecksumAddress,
+        from_private_key: PrivateKey,
+        tx_params: t.Optional[TxParams] = None,
+    ) -> TxReceipt:
+        return self.send(
+            from_address=from_address,
+            from_private_key=from_private_key,
+            function_name="sell",
+            function_params=[
+                amount_wei,
+                outcome_index,
+                max_outcome_tokens_to_sell,
+            ],
+            tx_params=tx_params,
+        )
+
+
+class WrappedxDaiContract(ContractERC20OnGnosisChain):
+    # File content taken from https://gnosisscan.io/address/0xe91d153e0b41518a2ce8dd3d7944fa863463a97d#code.
+    abi: ABI = abi_field_validator(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), "../../abis/wxdai.abi.json"
+        )
+    )
+    address: ChecksumAddress = Web3.to_checksum_address(
+        "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d"
+    )
+
+
+# Collateral token used on Omen is wrapped xDai.
+OmenCollateralTokenContract = WrappedxDaiContract
+
+OMEN_DEFAULT_MARKET_FEE = 0.02  # 2% fee from the buying shares amount.
+
+
+class OmenFixedProductMarketMakerFactoryContract(ContractOnGnosisChain):
+    # Contract ABI taken from https://gnosisscan.io/address/0x9083A2B699c0a4AD06F63580BDE2635d26a3eeF0#code.
+    abi: ABI = abi_field_validator(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "../../abis/omen_fpmm_factory.abi.json",
+        )
+    )
+    address: ChecksumAddress = Web3.to_checksum_address(
+        "0x9083A2B699c0a4AD06F63580BDE2635d26a3eeF0"
+    )
+
+    def create2FixedProductMarketMaker(
+        self,
+        condition_id: HexBytes,
+        initial_funds_wei: Wei,
+        from_address: ChecksumAddress,
+        from_private_key: PrivateKey,
+        fee: float = OMEN_DEFAULT_MARKET_FEE,
+        tx_params: t.Optional[TxParams] = None,
+    ) -> TxReceipt:
+        fee_wei = xdai_to_wei(
+            xdai_type(fee)
+        )  # We need to convert this to the wei units, but in reality it's % fee as stated in the `OMEN_DEFAULT_MARKET_FEE` variable.
+        return self.send(
+            from_address=from_address,
+            from_private_key=from_private_key,
+            function_name="create2FixedProductMarketMaker",
+            function_params=dict(
+                saltNonce=random.randint(
+                    0, 1000000
+                ),  # See https://github.com/protofire/omen-exchange/blob/923756c3a9ac370f8e89af8193393a53531e2c0f/app/src/services/cpk/fns.ts#L942.
+                conditionalTokens=OmenConditionalTokenContract().address,
+                collateralToken=OmenCollateralTokenContract().address,
+                conditionIds=[condition_id],
+                fee=fee_wei,
+                initialFunds=initial_funds_wei,
+                distributionHint=[],
+            ),
+            tx_params=tx_params,
+        )
+
+
+class Arbitrator(str, Enum):
+    KLEROS = "kleros"
+    DXDAO = "dxdao"
+
+
+class OmenDxDaoContract(ContractOnGnosisChain):
+    # Contract ABI taken from https://gnosisscan.io/address/0xFe14059344b74043Af518d12931600C0f52dF7c5#code.
+    abi: ABI = abi_field_validator(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "../../abis/omen_dxdao.abi.json",
+        )
+    )
+    address: ChecksumAddress = Web3.to_checksum_address(
+        "0xFe14059344b74043Af518d12931600C0f52dF7c5"
+    )
+
+
+class OmenKlerosContract(ContractOnGnosisChain):
+    # Contract ABI taken from https://gnosisscan.io/address/0xe40DD83a262da3f56976038F1554Fe541Fa75ecd#code.
+    abi: ABI = abi_field_validator(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "../../abis/omen_kleros.abi.json",
+        )
+    )
+    address: ChecksumAddress = Web3.to_checksum_address(
+        "0xe40DD83a262da3f56976038F1554Fe541Fa75ecd"
+    )
+
+
+class OmenRealitioContract(ContractOnGnosisChain):
+    # Contract ABI taken from https://gnosisscan.io/address/0x79e32aE03fb27B07C89c0c568F80287C01ca2E57#code.
+    abi: ABI = abi_field_validator(
+        os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "../../abis/omen_realitio.abi.json",
+        )
+    )
+    address: ChecksumAddress = Web3.to_checksum_address(
+        "0x79e32aE03fb27B07C89c0c568F80287C01ca2E57"
+    )
+
+    @staticmethod
+    def get_arbitrator_contract(
+        arbitrator: Arbitrator,
+    ) -> ContractOnGnosisChain:
+        if arbitrator == Arbitrator.KLEROS:
+            return OmenKlerosContract()
+        if arbitrator == Arbitrator.DXDAO:
+            return OmenDxDaoContract()
+        raise ValueError(f"Unknown arbitrator: {arbitrator}")
+
+    def askQuestion(
+        self,
+        question: str,
+        category: str,
+        outcomes: list[str],
+        language: str,
+        arbitrator: Arbitrator,
+        opening: datetime,
+        from_address: ChecksumAddress,
+        from_private_key: PrivateKey,
+        nonce: int | None = None,
+        tx_params: t.Optional[TxParams] = None,
+    ) -> HexBytes:
+        """
+        After the question is created, you can find it at https://reality.eth.link/app/#!/creator/{from_address}.
+        """
+        arbitrator_contract_address = self.get_arbitrator_contract(arbitrator).address
+        # See https://realitio.github.io/docs/html/contracts.html#templates
+        # for possible template ids and how to format the question.
+        template_id = 2
+        realitio_question = "␟".join(
+            [
+                question,
+                json.dumps(outcomes),
+                category,
+                language,
+            ]
+        )
+        receipt_tx = self.send(
+            from_address=from_address,
+            from_private_key=from_private_key,
+            function_name="askQuestion",
+            function_params=dict(
+                template_id=template_id,
+                question=realitio_question,
+                arbitrator=arbitrator_contract_address,
+                timeout=86400,  # See https://github.com/protofire/omen-exchange/blob/2cfdf6bfe37afa8b169731d51fea69d42321d66c/app/src/util/networks.ts#L278.
+                opening_ts=int(opening.timestamp()),
+                nonce=(
+                    nonce if nonce is not None else random.randint(0, 1000000)
+                ),  # Two equal questions need to have different nonces.
+            ),
+            tx_params=tx_params,
+        )
+        question_id: HexBytes = receipt_tx["logs"][0]["topics"][
+            1
+        ]  # The question id is available in the first emitted log, in the second topic.
+        return question_id

--- a/prediction_market_agent_tooling/markets/omen/omen_contracts.py
+++ b/prediction_market_agent_tooling/markets/omen/omen_contracts.py
@@ -19,7 +19,6 @@ from prediction_market_agent_tooling.gtypes import (
     Wei,
     xdai_type,
 )
-from prediction_market_agent_tooling.markets.omen.omen import OmenAgentMarket
 from prediction_market_agent_tooling.tools.contract import (
     ContractERC20OnGnosisChain,
     ContractOnGnosisChain,
@@ -140,14 +139,6 @@ class OmenFixedProductMarketMakerContract(ContractOnGnosisChain):
 
     # ! Note: This doesn't have a fixed contract address, as this is something created by the `OmenFixedProductMarketMakerFactory`.
     # Factory contract at https://gnosisscan.io/address/0x9083a2b699c0a4ad06f63580bde2635d26a3eef0.
-
-    @staticmethod
-    def from_agent_market(
-        market: OmenAgentMarket,
-    ) -> "OmenFixedProductMarketMakerContract":
-        return OmenFixedProductMarketMakerContract(
-            address=market.market_maker_contract_address_checksummed
-        )
 
     def calcBuyAmount(
         self,

--- a/prediction_market_agent_tooling/tools/contract.py
+++ b/prediction_market_agent_tooling/tools/contract.py
@@ -1,0 +1,194 @@
+import json
+import typing as t
+
+from pydantic import BaseModel, field_validator
+from web3 import Web3
+
+from prediction_market_agent_tooling.gtypes import (
+    ABI,
+    ChainID,
+    ChecksumAddress,
+    PrivateKey,
+    TxParams,
+    TxReceipt,
+    Wei,
+)
+from prediction_market_agent_tooling.tools.gnosis_rpc import (
+    GNOSIS_NETWORK_ID,
+    GNOSIS_RPC_URL,
+)
+from prediction_market_agent_tooling.tools.web3_utils import (
+    call_function_on_contract,
+    send_function_on_contract_tx,
+)
+
+
+def abi_field_validator(value: str) -> ABI:
+    if value.endswith(".json"):
+        with open(value) as f:
+            value = f.read()
+
+    try:
+        json.loads(value)  # Test if it's valid JSON content.
+        return ABI(value)
+    except json.decoder.JSONDecodeError:
+        raise ValueError(f"Invalid ABI: {value}")
+
+
+class ContractBaseClass(BaseModel):
+    """
+    Base class holding the basic requirements and tools used for every contract.
+    """
+
+    CHAIN_ID: t.ClassVar[ChainID]
+    CHAIN_RPC_URL: t.ClassVar[str]
+
+    abi: ABI
+    address: ChecksumAddress
+
+    _abi_field_validator = field_validator("abi", mode="before")(abi_field_validator)
+
+    def call(
+        self,
+        function_name: str,
+        function_params: t.Optional[list[t.Any] | dict[str, t.Any]] = None,
+        web3: Web3 | None = None,
+    ) -> t.Any:
+        """
+        Used for reading from the contract.
+        """
+        web3 = web3 or self.get_web3()
+        return call_function_on_contract(
+            web3=web3,
+            contract_address=self.address,
+            contract_abi=self.abi,
+            function_name=function_name,
+            function_params=function_params,
+        )
+
+    def send(
+        self,
+        from_address: ChecksumAddress,
+        from_private_key: PrivateKey,
+        function_name: str,
+        function_params: t.Optional[list[t.Any] | dict[str, t.Any]] = None,
+        tx_params: t.Optional[TxParams] = None,
+        timeout: int = 180,
+        web3: Web3 | None = None,
+    ) -> TxReceipt:
+        """
+        Used for changing a state (writing) to the contract.
+        """
+        web3 = web3 or self.get_web3()
+        return send_function_on_contract_tx(
+            web3=web3,
+            contract_address=self.address,
+            contract_abi=self.abi,
+            from_address=from_address,
+            from_private_key=from_private_key,
+            function_name=function_name,
+            function_params=function_params,
+            tx_params=tx_params,
+            timeout=timeout,
+        )
+
+    def send_with_value(
+        self,
+        from_address: ChecksumAddress,
+        from_private_key: PrivateKey,
+        function_name: str,
+        amount_wei: Wei,
+        function_params: t.Optional[list[t.Any] | dict[str, t.Any]] = None,
+        tx_params: t.Optional[TxParams] = None,
+        timeout: int = 180,
+        web3: Web3 | None = None,
+    ) -> TxReceipt:
+        """
+        Used for changing a state (writing) to the contract, including sending chain's native currency.
+        """
+        return self.send(
+            from_address=from_address,
+            from_private_key=from_private_key,
+            function_name=function_name,
+            function_params=function_params,
+            tx_params={"value": amount_wei, **(tx_params or {})},
+            timeout=timeout,
+            web3=web3,
+        )
+
+    def get_web3(self) -> Web3:
+        return Web3(Web3.HTTPProvider(self.CHAIN_RPC_URL))
+
+
+class ContractERC20BaseClass(ContractBaseClass):
+    """
+    Contract base class extended by ERC-20 standard methods.
+    """
+
+    def approve(
+        self,
+        for_address: ChecksumAddress,
+        amount_wei: Wei,
+        from_address: ChecksumAddress,
+        from_private_key: PrivateKey,
+        tx_params: t.Optional[TxParams] = None,
+    ) -> TxReceipt:
+        return self.send(
+            from_address=from_address,
+            from_private_key=from_private_key,
+            function_name="approve",
+            function_params=[
+                for_address,
+                amount_wei,
+            ],
+            tx_params=tx_params,
+        )
+
+    def deposit(
+        self,
+        amount_wei: Wei,
+        from_address: ChecksumAddress,
+        from_private_key: PrivateKey,
+        tx_params: t.Optional[TxParams] = None,
+    ) -> TxReceipt:
+        return self.send_with_value(
+            from_address=from_address,
+            from_private_key=from_private_key,
+            function_name="deposit",
+            amount_wei=amount_wei,
+            tx_params=tx_params,
+        )
+
+    def withdraw(
+        self,
+        amount_wei: Wei,
+        from_address: ChecksumAddress,
+        from_private_key: PrivateKey,
+        tx_params: t.Optional[TxParams] = None,
+    ) -> TxReceipt:
+        return self.send(
+            from_address=from_address,
+            from_private_key=from_private_key,
+            function_name="withdraw",
+            function_params=[amount_wei],
+            tx_params=tx_params,
+        )
+
+    def balanceOf(self, for_address: ChecksumAddress) -> Wei:
+        balance: Wei = self.call("balanceOf", [for_address])
+        return balance
+
+
+class ContractOnGnosisChain(ContractBaseClass):
+    """
+    Contract base class with Gnosis Chain configuration.
+    """
+
+    CHAIN_ID = GNOSIS_NETWORK_ID
+    CHAIN_RPC_URL = GNOSIS_RPC_URL
+
+
+class ContractERC20OnGnosisChain(ContractERC20BaseClass, ContractOnGnosisChain):
+    """
+    ERC-20 standard base class with Gnosis Chain configuration.
+    """

--- a/prediction_market_agent_tooling/tools/gnosis_rpc.py
+++ b/prediction_market_agent_tooling/tools/gnosis_rpc.py
@@ -1,8 +1,10 @@
 import os
 
 import requests
-from web3.types import Wei
 
+from prediction_market_agent_tooling.gtypes import ChainID, Wei
+
+GNOSIS_NETWORK_ID = ChainID(100)  # xDai network.
 GNOSIS_RPC_URL = os.getenv("GNOSIS_RPC_URL", "https://gnosis-rpc.publicnode.com")
 
 

--- a/prediction_market_agent_tooling/tools/web3_utils.py
+++ b/prediction_market_agent_tooling/tools/web3_utils.py
@@ -1,4 +1,3 @@
-import os
 from decimal import Decimal
 from typing import Any, Optional, TypeVar
 
@@ -16,18 +15,8 @@ from prediction_market_agent_tooling.gtypes import (
     xdai_type,
 )
 
-GNOSIS_NETWORK_ID = 100  # xDai network.
 ONE_NONCE = Nonce(1)
 ONE_XDAI = xdai_type(1)
-
-with open(
-    os.path.join(os.path.dirname(os.path.realpath(__file__)), "../abis/wxdai.abi.json")
-) as f:
-    # File content taken from https://gnosisscan.io/address/0xe91d153e0b41518a2ce8dd3d7944fa863463a97d#code.
-    WXDAI_ABI = ABI(f.read())
-    WXDAI_CONTRACT_ADDRESS: ChecksumAddress = Web3.to_checksum_address(
-        "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d"
-    )
 
 
 def wei_to_xdai(wei: Wei) -> xDai:
@@ -107,7 +96,7 @@ def call_function_on_contract(
     retry=tenacity.retry_if_exception_message(match=".*wrong transaction nonce.*"),
     wait=tenacity.wait_chain(*[tenacity.wait_fixed(n) for n in range(1, 6)]),
 )
-def call_function_on_contract_tx(
+def send_function_on_contract_tx(
     web3: Web3,
     *,
     contract_address: ChecksumAddress,

--- a/tests/markets/test_betting_strategies.py
+++ b/tests/markets/test_betting_strategies.py
@@ -9,7 +9,9 @@ from prediction_market_agent_tooling.markets.manifold.manifold import (
     ManifoldAgentMarket,
 )
 from prediction_market_agent_tooling.markets.omen.omen import OmenAgentMarket
-from prediction_market_agent_tooling.tools.web3_utils import WXDAI_CONTRACT_ADDRESS
+from prediction_market_agent_tooling.markets.omen.omen_contracts import (
+    OmenCollateralTokenContract,
+)
 
 
 @pytest.mark.parametrize(
@@ -31,7 +33,7 @@ def test_minimum_bet_to_win(
             question="question",
             outcomes=["Yes", "No"],
             p_yes=market_p_yes,
-            collateral_token_contract_address_checksummed=WXDAI_CONTRACT_ADDRESS,
+            collateral_token_contract_address_checksummed=OmenCollateralTokenContract().address,
             market_maker_contract_address_checksummed=Web3.to_checksum_address(
                 "0xf3318C420e5e30C12786C4001D600e9EE1A7eBb1"
             ),

--- a/tests/markets/test_omen.py
+++ b/tests/markets/test_omen.py
@@ -51,19 +51,22 @@ def test_omen_buy_and_sell_outcome() -> None:
     # Tests both buying and selling, so we are back at the square one in the wallet (minues fees).
     # You can double check your address at https://gnosisscan.io/ afterwards.
     market = OmenAgentMarket.from_data_model(pick_binary_market())
-    amount = xdai_type(0.00142)
+    buy_amount = xdai_type(0.00142)
+    sell_amount = xdai_type(
+        buy_amount / 2
+    )  # There will be some fees, so this has to be lower.
     keys = APIKeys()
     binary_omen_buy_outcome_tx(
-        amount=amount,
+        amount=buy_amount,
         from_address=keys.bet_from_address,
         from_private_key=keys.bet_from_private_key,
         market=market,
         binary_outcome=True,
         auto_deposit=True,
     )
-    time.sleep(3.14)  # Wait for the transaction to be mined.
+    time.sleep(10)  # Wait for the transaction to be mined.
     binary_omen_sell_outcome_tx(
-        amount=amount,
+        amount=sell_amount,
         from_address=keys.bet_from_address,
         from_private_key=keys.bet_from_private_key,
         market=market,

--- a/tests/markets/test_omen.py
+++ b/tests/markets/test_omen.py
@@ -9,6 +9,8 @@ from prediction_market_agent_tooling.config import APIKeys
 from prediction_market_agent_tooling.gtypes import xdai_type
 from prediction_market_agent_tooling.markets.agent_market import FilterBy, SortBy
 from prediction_market_agent_tooling.markets.omen.omen import (
+    OMEN_FALSE_OUTCOME,
+    OMEN_TRUE_OUTCOME,
     OmenAgentMarket,
     binary_omen_buy_outcome_tx,
     binary_omen_sell_outcome_tx,
@@ -16,6 +18,7 @@ from prediction_market_agent_tooling.markets.omen.omen import (
     get_omen_bets,
     get_omen_binary_markets,
     get_resolved_omen_bets,
+    omen_create_market_tx,
     pick_binary_market,
 )
 from prediction_market_agent_tooling.tools.utils import check_not_none
@@ -65,6 +68,22 @@ def test_omen_buy_and_sell_outcome() -> None:
         market=market,
         binary_outcome=True,
         auto_withdraw=True,
+    )
+
+
+@pytest.mark.skipif(not RUN_PAID_TESTS, reason="This test costs money to run.")
+def test_omen_create_market() -> None:
+    keys = APIKeys()
+    omen_create_market_tx(
+        initial_funds=xdai_type(0.001),
+        question="Will GNO hit $1000 by the end of the current year?",
+        closing_time=datetime(year=datetime.utcnow().year, day=24, month=12),
+        category="cryptocurrency",
+        language="en",
+        from_address=keys.bet_from_address,
+        from_private_key=keys.bet_from_private_key,
+        outcomes=[OMEN_TRUE_OUTCOME, OMEN_FALSE_OUTCOME],
+        auto_deposit=True,
     )
 
 

--- a/tests/markets/test_omen.py
+++ b/tests/markets/test_omen.py
@@ -51,7 +51,7 @@ def test_omen_buy_and_sell_outcome() -> None:
     # Tests both buying and selling, so we are back at the square one in the wallet (minues fees).
     # You can double check your address at https://gnosisscan.io/ afterwards.
     market = OmenAgentMarket.from_data_model(pick_binary_market())
-    amount = xdai_type(0.001)
+    amount = xdai_type(0.00142)
     keys = APIKeys()
     binary_omen_buy_outcome_tx(
         amount=amount,

--- a/tests/markets/test_omen.py
+++ b/tests/markets/test_omen.py
@@ -49,6 +49,7 @@ def test_omen_get_market() -> None:
 @pytest.mark.skipif(not RUN_PAID_TESTS, reason="This test costs money to run.")
 def test_omen_buy_and_sell_outcome() -> None:
     # Tests both buying and selling, so we are back at the square one in the wallet (minues fees).
+    # You can double check your address at https://gnosisscan.io/ afterwards.
     market = OmenAgentMarket.from_data_model(pick_binary_market())
     amount = xdai_type(0.001)
     keys = APIKeys()
@@ -73,6 +74,7 @@ def test_omen_buy_and_sell_outcome() -> None:
 
 @pytest.mark.skipif(not RUN_PAID_TESTS, reason="This test costs money to run.")
 def test_omen_create_market() -> None:
+    # You can double check on https://aiomen.eth.limo/#/newest afterwards.
     keys = APIKeys()
     omen_create_market_tx(
         initial_funds=xdai_type(0.001),


### PR DESCRIPTION
Introduced `ContractBaseClass` base class. Contracts (wxDai, Market, Condition tokens, etc.) are now subclasses of it. And every contract class holds the methods that actual contract on chain implements. 

It's inspired from Omen's frontend code.

So, instead of passing around ABIs and addresses, we call the methods of contract and it's a lot cleaner than before.

Also, this allows us to implement standards, such as `ContractERC20BaseClass` and then wxDai is just `ContractERC20OnGnosisChain(ContractERC20BaseClass)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced market creation, buying, and selling functionalities for Omen prediction markets.
	- Introduced a new module for interacting with Omen contracts, improving efficiency in market replication and interaction with various contracts.
- **Refactor**
	- Significant refactoring of the Omen market-related code for better structure and efficiency.
- **Tests**
	- Added new tests for betting strategies and market creation in Omen prediction markets.
- **Documentation**
	- Updated examples to demonstrate the use of new functionalities in market replication and interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->