### PR TITLE
Add Brier Score metric and table to monitoring

### DIFF
--- a/prediction_market_agent_tooling/markets/agent_market.py
+++ b/prediction_market_agent_tooling/markets/agent_market.py
@@ -43,6 +43,14 @@ class AgentMarket(BaseModel):
     def p_no(self) -> float:
         return 1 - self.p_yes
 
+    @property
+    def boolean_outcome(self) -> bool:
+        if not self.has_successful_resolution():
+            raise ValueError(
+                "Market must have successful resolution to compute boolean outcome."
+            )
+        return self.resolution == Resolution.YES
+
     def get_bet_amount(self, amount: Decimal) -> BetAmount:
         return BetAmount(amount=amount, currency=self.currency)
 
@@ -80,3 +88,6 @@ class AgentMarket(BaseModel):
             return self.outcomes.index(outcome)
         except ValueError:
             raise ValueError(f"Outcome `{outcome}` not found in `{self.outcomes}`.")
+
+    def get_squared_error(self) -> float:
+        return (self.p_yes - self.boolean_outcome) ** 2

--- a/prediction_market_agent_tooling/markets/agent_market.py
+++ b/prediction_market_agent_tooling/markets/agent_market.py
@@ -49,7 +49,7 @@ class AgentMarket(BaseModel):
             raise ValueError(
                 "Market must have successful resolution to compute boolean outcome."
             )
-        return self.resolution == Resolution.YES
+        return True if self.resolution == Resolution.YES else False if self.resolution == Resolution.NO else should_not_happen(f"Probably a bug in self.has_successful_resolution")
 
     def get_bet_amount(self, amount: Decimal) -> BetAmount:
         return BetAmount(amount=amount, currency=self.currency)

--- a/prediction_market_agent_tooling/markets/agent_market.py
+++ b/prediction_market_agent_tooling/markets/agent_market.py
@@ -11,6 +11,7 @@ from prediction_market_agent_tooling.markets.data_models import (
     Currency,
     Resolution,
 )
+from prediction_market_agent_tooling.tools.utils import should_not_happen
 
 
 class SortBy(str, Enum):
@@ -45,11 +46,12 @@ class AgentMarket(BaseModel):
 
     @property
     def boolean_outcome(self) -> bool:
-        if not self.has_successful_resolution():
-            raise ValueError(
-                "Market must have successful resolution to compute boolean outcome."
-            )
-        return True if self.resolution == Resolution.YES else False if self.resolution == Resolution.NO else should_not_happen(f"Probably a bug in self.has_successful_resolution")
+        if self.resolution:
+            if self.resolution == Resolution.YES:
+                return True
+            elif self.resolution == Resolution.NO:
+                return False
+        should_not_happen(f"Market {self.id} does not have a successful resolution.")
 
     def get_bet_amount(self, amount: Decimal) -> BetAmount:
         return BetAmount(amount=amount, currency=self.currency)

--- a/prediction_market_agent_tooling/monitor/monitor.py
+++ b/prediction_market_agent_tooling/monitor/monitor.py
@@ -216,7 +216,7 @@ def monitor_brier_score(resolved_markets: list[AgentMarket]) -> None:
     - the overall brier score
     - the brier score for the last 30 markets
     """
-    st.subheader("Brier Score")
+    st.subheader("Brier Score (0-1, lower is better)")
 
     markets_to_squared_error = {
         m.created_time: m.get_squared_error() for m in resolved_markets
@@ -225,21 +225,21 @@ def monitor_brier_score(resolved_markets: list[AgentMarket]) -> None:
         markets_to_squared_error.items(), columns=["Date", "Squared Error"]
     ).sort_values(by="Date")
 
-    # Compute rolling mean squared error for last 10 markets
-    df["Rolling Mean Squared Error"] = df["Squared Error"].rolling(window=10).mean()
+    # Compute rolling mean squared error for last 30 markets
+    df["Rolling Mean Squared Error"] = df["Squared Error"].rolling(window=30).mean()
 
     col1, col2 = st.columns(2)
-    col1.metric(label="Overall", value=f"{df['Squared Error'].mean():.2f}")
+    col1.metric(label="Overall", value=f"{df['Squared Error'].mean():.3f}")
     col2.metric(
-        label="Last 30 markets", value=f"{df['Squared Error'].tail(30).mean():.2f}"
+        label="Last 30 markets", value=f"{df['Squared Error'].tail(30).mean():.3f}"
     )
 
     st.altair_chart(
         alt.Chart(df)
-        .mark_line()
+        .mark_line(interpolate="basis")
         .encode(
             x="Date:T",
-            y="Rolling Mean Squared Error:Q",
+            y=alt.Y("Rolling Mean Squared Error:Q", scale=alt.Scale(domain=[0, 1])),
         )
         .interactive(),
         use_container_width=True,

--- a/prediction_market_agent_tooling/monitor/monitor.py
+++ b/prediction_market_agent_tooling/monitor/monitor.py
@@ -198,6 +198,59 @@ def monitor_agent(agent: DeployedAgent) -> None:
 def monitor_market(
     open_markets: list[AgentMarket], resolved_markets: list[AgentMarket]
 ) -> None:
+    col1, col2 = st.columns(2)
+    col1.metric(label="Number open markets", value=f"{len(open_markets)}")
+    col2.metric(label="Number resolved markets", value=f"{len(resolved_markets)}")
+
+    monitor_brier_score(resolved_markets)
+    monitor_market_outcome_bias(open_markets, resolved_markets)
+
+
+def monitor_brier_score(resolved_markets: list[AgentMarket]) -> None:
+    """
+    https://en.wikipedia.org/wiki/Brier_score
+
+    Calculate the Brier score for the resolved markets. Display a chart of the
+    rolling mean squared error for, and stats for:
+
+    - the overall brier score
+    - the brier score for the last 30 markets
+    """
+    st.subheader("Brier Score")
+
+    markets_to_squared_error = {
+        m.created_time: m.get_squared_error() for m in resolved_markets
+    }
+    df = pd.DataFrame(
+        markets_to_squared_error.items(), columns=["Date", "Squared Error"]
+    ).sort_values(by="Date")
+
+    # Compute rolling mean squared error for last 10 markets
+    df["Rolling Mean Squared Error"] = df["Squared Error"].rolling(window=10).mean()
+
+    col1, col2 = st.columns(2)
+    col1.metric(label="Overall", value=f"{df['Squared Error'].mean():.2f}")
+    col2.metric(
+        label="Last 30 markets", value=f"{df['Squared Error'].tail(30).mean():.2f}"
+    )
+
+    st.altair_chart(
+        alt.Chart(df)
+        .mark_line()
+        .encode(
+            x="Date:T",
+            y="Rolling Mean Squared Error:Q",
+        )
+        .interactive(),
+        use_container_width=True,
+    )
+
+
+def monitor_market_outcome_bias(
+    open_markets: list[AgentMarket], resolved_markets: list[AgentMarket]
+) -> None:
+    st.subheader("Market Outcome Bias")
+
     date_to_open_yes_proportion = {
         d: np.mean([int(m.p_yes > 0.5) for m in markets])
         for d, markets in groupby(open_markets, lambda x: x.created_time.date())
@@ -264,8 +317,6 @@ def monitor_market(
         ]
     )
     st.markdown(
-        f"Total number of open markets {len(open_markets)} and resolved markets {len(resolved_markets)}"
-        "\n\n"
         f"Mean proportion of 'YES' in open markets: {all_open_markets_yes_mean:.2f}"
         "\n\n"
         f"Mean proportion of 'YES' in resolved markets: {all_resolved_markets_yes_mean:.2f}"

--- a/prediction_market_agent_tooling/monitor/monitor_app.py
+++ b/prediction_market_agent_tooling/monitor/monitor_app.py
@@ -83,7 +83,6 @@ def monitor_app() -> None:
     market_type: MarketType = check_not_none(
         st.selectbox(label="Market type", options=list(MarketType), index=0)
     )
-    market_type = MarketType.OMEN
     start_time: DatetimeWithTimezone | None = (
         add_utc_timezone_validator(
             datetime.combine(

--- a/prediction_market_agent_tooling/monitor/monitor_app.py
+++ b/prediction_market_agent_tooling/monitor/monitor_app.py
@@ -83,6 +83,7 @@ def monitor_app() -> None:
     market_type: MarketType = check_not_none(
         st.selectbox(label="Market type", options=list(MarketType), index=0)
     )
+    market_type = MarketType.OMEN
     start_time: DatetimeWithTimezone | None = (
         add_utc_timezone_validator(
             datetime.combine(
@@ -114,7 +115,7 @@ def monitor_app() -> None:
         else datetime(2020, 1, 1, tzinfo=pytz.UTC)
     )
 
-    st.subheader("Market resolution")
+    st.header("Market Info")
     with st.spinner("Loading markets"):
         open_markets, resolved_markets = get_open_and_resolved_markets(
             start_time=oldest_start_time, market_type=market_type
@@ -125,7 +126,7 @@ def monitor_app() -> None:
         else st.warning("No market data found.")
     )
 
-    st.subheader("Agent bets")
+    st.header("Agent Info")
     for agent in agents:
         with st.expander(f"Agent: '{agent.name}'"):
             monitor_agent(agent)


### PR DESCRIPTION
Before:
<img width="1352" alt="Screenshot 2024-03-09 at 00 59 17" src="https://github.com/gnosis/prediction-market-agent-tooling/assets/56087052/3115e407-e6bf-493d-9d49-71ddaf654e2d">

After:
<img width="1347" alt="Screenshot 2024-03-09 at 00 53 22" src="https://github.com/gnosis/prediction-market-agent-tooling/assets/56087052/c20ac6e2-0697-4eb1-8c05-aeba357fa093">

Noticing a couple existing bugs(?) to investigate and fix in future PRs:
- Manifold brier score seems too low. [This](https://www.metaculus.com/notebooks/15359/predictive-performance-on-metaculus-vs-manifold-markets/) suggests it should be ~0.1 as apposed to ~0.03
- Something's not right with resolved Omen markets - most have [0, 0] outcome tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
    - Introduced a feature to compute boolean outcomes for market resolutions.
    - Added functionality to calculate and display Brier scores for market predictions.
    - Enhanced market monitoring with the addition of market outcome bias metrics.
- **Refactor**
    - Adjusted the monitoring application to improve information presentation and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->