### PR TITLE
Port betting strategies from prediction-market-agent repo

### DIFF
--- a/prediction_market_agent_tooling/tools/betting_strategies/kelly_criterion.py
+++ b/prediction_market_agent_tooling/tools/betting_strategies/kelly_criterion.py
@@ -1,0 +1,110 @@
+import typing as t
+
+from prediction_market_agent_tooling.gtypes import Probability, wei_type, xDai
+from prediction_market_agent_tooling.markets.omen.data_models import OmenMarket
+from prediction_market_agent_tooling.tools.utils import check_not_none
+from prediction_market_agent_tooling.tools.web3_utils import (
+    ONE_XDAI,
+    wei_to_xdai,
+    xdai_to_wei,
+)
+
+OutcomeIndex = t.Literal[0, 1]
+
+
+def _get_kelly_criterion_bet(
+    x: int, y: int, p: float, c: float, b: int, f: float
+) -> int:
+    """
+    Implments https://en.wikipedia.org/wiki/Kelly_criterion
+
+    Taken from https://github.com/valory-xyz/trader/blob/main/strategies/kelly_criterion/kelly_criterion.py
+
+    ```
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    ```
+
+    x: Number of tokens in the selected outcome pool
+    y: Number of tokens in the other outcome pool
+    p: Probability of winning
+    c: Confidence
+    b: Bankroll
+    f: Fee fraction
+    """
+    if b == 0:
+        return 0
+    numerator = (
+        -4 * x**2 * y
+        + b * y**2 * p * c * f
+        + 2 * b * x * y * p * c * f
+        + b * x**2 * p * c * f
+        - 2 * b * y**2 * f
+        - 2 * b * x * y * f
+        + (
+            (
+                4 * x**2 * y
+                - b * y**2 * p * c * f
+                - 2 * b * x * y * p * c * f
+                - b * x**2 * p * c * f
+                + 2 * b * y**2 * f
+                + 2 * b * x * y * f
+            )
+            ** 2
+            - (
+                4
+                * (x**2 * f - y**2 * f)
+                * (
+                    -4 * b * x * y**2 * p * c
+                    - 4 * b * x**2 * y * p * c
+                    + 4 * b * x * y**2
+                )
+            )
+        )
+        ** (1 / 2)
+    )
+    denominator = 2 * (x**2 * f - y**2 * f)
+    if denominator == 0:
+        return 0
+    kelly_bet_amount = numerator / denominator
+    return int(kelly_bet_amount)
+
+
+def get_kelly_criterion_bet(
+    market: OmenMarket,
+    estimated_p_yes: Probability,
+    max_bet: xDai,
+) -> t.Tuple[xDai, OutcomeIndex]:
+    if len(market.outcomeTokenAmounts) != 2:
+        raise ValueError("Only binary markets are supported.")
+
+    current_p_yes = check_not_none(
+        market.outcomeTokenProbabilities, "No probabilities, is marked closed?"
+    )[0]
+    outcome_index: OutcomeIndex = 0 if estimated_p_yes > current_p_yes else 1
+    estimated_p_win = estimated_p_yes if outcome_index == 0 else 1 - estimated_p_yes
+
+    kelly_bet_wei = wei_type(
+        _get_kelly_criterion_bet(
+            x=market.outcomeTokenAmounts[outcome_index],
+            y=market.outcomeTokenAmounts[1 - outcome_index],
+            p=estimated_p_win,
+            c=1,  # confidence
+            b=xdai_to_wei(max_bet),  # bankroll, or max bet, in Wei
+            f=(
+                xdai_to_wei(ONE_XDAI)
+                - check_not_none(market.fee, "No fee for the market.")
+            )
+            / xdai_to_wei(ONE_XDAI),  # fee fraction
+        )
+    )
+    return wei_to_xdai(kelly_bet_wei), outcome_index

--- a/prediction_market_agent_tooling/tools/betting_strategies/market_moving.py
+++ b/prediction_market_agent_tooling/tools/betting_strategies/market_moving.py
@@ -1,0 +1,115 @@
+import typing as t
+from functools import reduce
+
+import numpy as np
+
+from prediction_market_agent_tooling.gtypes import Probability, wei_type, xDai
+from prediction_market_agent_tooling.markets.omen.data_models import OmenMarket
+from prediction_market_agent_tooling.markets.omen.omen import OmenAgentMarket
+from prediction_market_agent_tooling.tools.utils import check_not_none
+from prediction_market_agent_tooling.tools.web3_utils import (
+    ONE_XDAI,
+    wei_to_xdai,
+    xdai_to_wei,
+)
+
+OutcomeIndex = t.Literal[0, 1]
+
+
+def get_market_moving_bet(
+    market: OmenMarket,
+    target_p_yes: Probability,
+    max_iters: int = 100,
+    check_vs_contract: bool = False,  # Disable by default, as it's slow
+    verbose: bool = False,
+) -> t.Tuple[xDai, OutcomeIndex]:
+    """
+    Implements a binary search to determine the bet that will move the market's
+    `p_yes` to that of the target.
+
+    Consider a binary fixed-product market containing `x` and `y` tokens.
+    A trader wishes to aquire `x` tokens by betting an amount `d0`.
+
+    The calculation to determine the number of `x` tokens he acquires, denoted
+    by `dx`, is:
+
+    a_x * a_y = fixed_product
+    na_x = a_x + d0
+    na_y = a_y + d0
+    na_x * na_y = new_product
+    (na_x - dx) * na_y = fixed_product
+    (na_x * na_y) - (dx * na_y) = fixed_product
+    new_product - fixed_product = dx * na_y
+    dx = (new_product - fixed_product) / na_y
+    """
+    market_agent = OmenAgentMarket.from_data_model(market)
+    amounts = market.outcomeTokenAmounts
+    prices = check_not_none(
+        market.outcomeTokenProbabilities, "No probabilities, is marked closed?"
+    )
+    if len(amounts) != 2 or len(prices) != 2:
+        raise ValueError("Only binary markets are supported.")
+
+    fixed_product = reduce(lambda x, y: x * y, amounts, 1)
+    assert np.isclose(float(sum(prices)), 1)
+
+    # For FPMMs, the probability is equal to the marginal price
+    current_p_yes = Probability(prices[0])
+    bet_outcome_index: OutcomeIndex = 0 if target_p_yes > current_p_yes else 1
+
+    min_bet_amount = 0
+    max_bet_amount = 100 * sum(amounts)  # TODO set a better upper bound
+
+    # Binary search for the optimal bet amount
+    for _ in range(max_iters):
+        bet_amount = (min_bet_amount + max_bet_amount) // 2
+        bet_amount_ = (
+            bet_amount
+            * (
+                xdai_to_wei(ONE_XDAI)
+                - check_not_none(market.fee, "No fee for the market.")
+            )
+            / xdai_to_wei(ONE_XDAI)
+        )
+
+        # Initial new amounts are old amounts + equal new amounts for each outcome
+        amounts_diff = bet_amount_
+        new_amounts = [amounts[i] + amounts_diff for i in range(len(amounts))]
+
+        # Now give away tokens at `bet_outcome_index` to restore invariant
+        new_product = reduce(lambda x, y: x * y, new_amounts, 1.0)
+        dx = (new_product - fixed_product) / new_amounts[1 - bet_outcome_index]
+
+        # Sanity check the number of tokens against the contract
+        if check_vs_contract:
+            expected_trade = market_agent.get_contract().calcBuyAmount(
+                investment_amount=wei_type(bet_amount),
+                outcome_index=bet_outcome_index,
+            )
+            assert np.isclose(float(expected_trade), dx)
+
+        new_amounts[bet_outcome_index] -= dx
+        # Check that the invariant is restored
+        assert np.isclose(
+            reduce(lambda x, y: x * y, new_amounts, 1.0), float(fixed_product)
+        )
+        new_p_yes = Probability(new_amounts[1] / sum(new_amounts))
+        bet_amount_wei = wei_type(bet_amount)
+        if verbose:
+            outcome = market_agent.get_outcome_str(bet_outcome_index)
+            print(
+                f"Target p_yes: {target_p_yes:.2f}, bet: {wei_to_xdai(bet_amount_wei):.2f}{market_agent.currency} for {outcome}, new p_yes: {new_p_yes:.2f}"
+            )
+        if abs(target_p_yes - new_p_yes) < 0.01:
+            break
+        elif new_p_yes > target_p_yes:
+            if bet_outcome_index == 0:
+                max_bet_amount = bet_amount
+            else:
+                min_bet_amount = bet_amount
+        else:
+            if bet_outcome_index == 0:
+                min_bet_amount = bet_amount
+            else:
+                max_bet_amount = bet_amount
+    return wei_to_xdai(bet_amount_wei), bet_outcome_index

--- a/tests/markets/test_betting_strategies.py
+++ b/tests/markets/test_betting_strategies.py
@@ -1,21 +1,64 @@
 from datetime import datetime
 
+import numpy as np
 import pytest
 from eth_typing import HexAddress, HexStr
 from web3 import Web3
 
-from prediction_market_agent_tooling.gtypes import Probability
+from prediction_market_agent_tooling.gtypes import (
+    OmenOutcomeToken,
+    Probability,
+    Wei,
+    usd_type,
+    wei_type,
+    xDai,
+    xdai_type,
+)
 from prediction_market_agent_tooling.markets.betting_strategies import (
     minimum_bet_to_win,
 )
 from prediction_market_agent_tooling.markets.manifold.manifold import (
     ManifoldAgentMarket,
 )
-from prediction_market_agent_tooling.markets.omen.data_models import Condition
+from prediction_market_agent_tooling.markets.omen.data_models import (
+    Condition,
+    OmenMarket,
+)
 from prediction_market_agent_tooling.markets.omen.omen import OmenAgentMarket
 from prediction_market_agent_tooling.markets.omen.omen_contracts import (
     OmenCollateralTokenContract,
 )
+from prediction_market_agent_tooling.tools.betting_strategies.kelly_criterion import (
+    get_kelly_criterion_bet,
+)
+from prediction_market_agent_tooling.tools.betting_strategies.market_moving import (
+    get_market_moving_bet,
+)
+
+
+@pytest.fixture
+def omen_market() -> OmenMarket:
+    return OmenMarket(
+        id=HexAddress(HexStr("0x76a7a3487f85390dc568f3fce01e0a649cb39651")),
+        title="Will Plex launch a store for movies and TV shows by 26 January 2024?",
+        collateralVolume=Wei(4369016776639073062),
+        usdVolume=usd_type("4.369023756584789670441178585394842"),
+        collateralToken=HexAddress(
+            HexStr("0xe91d153e0b41518a2ce8dd3d7944fa863463a97d")
+        ),
+        outcomes=["Yes", "No"],
+        outcomeTokenAmounts=[
+            OmenOutcomeToken(7277347438897016099),
+            OmenOutcomeToken(13741270543921756242),
+        ],
+        outcomeTokenMarginalPrices=[
+            xdai_type("0.6537666061181695741160552853310822"),
+            xdai_type("0.3462333938818304258839447146689178"),
+        ],
+        fee=wei_type(20000000000000000),
+        category="foo",
+        condition=Condition(id=HexAddress(HexStr("0x123")), outcomeSlotCount=2),
+    )
 
 
 @pytest.mark.parametrize(
@@ -72,3 +115,51 @@ def test_minimum_bet_to_win_manifold(
         created_time=datetime.now(),
     ).get_minimum_bet_to_win(outcome, amount_to_win)
     assert min_bet == expected_min_bet, f"Expected {expected_min_bet}, got {min_bet}."
+
+
+@pytest.mark.parametrize(
+    "wanted_p_yes_on_the_market, expected_buying_xdai_amount, expected_buying_outcome",
+    [
+        (Probability(0.1), xdai_type(25.32), "No"),
+        (Probability(0.9), xdai_type(18.1), "Yes"),
+    ],
+)
+def test_get_market_moving_bet(
+    wanted_p_yes_on_the_market: Probability,
+    expected_buying_xdai_amount: xDai,
+    expected_buying_outcome: str,
+    omen_market: OmenMarket,
+) -> None:
+    xdai_amount, outcome_index = get_market_moving_bet(
+        market=omen_market,
+        target_p_yes=wanted_p_yes_on_the_market,
+        verbose=True,
+    )
+    assert np.isclose(
+        float(xdai_amount),
+        float(expected_buying_xdai_amount),
+        atol=2.0,  # We don't expect it to be 100% accurate, but close enough.
+    ), f"To move this martket to ~{wanted_p_yes_on_the_market}% for yes, the amount should be {expected_buying_xdai_amount}xDai, according to aiomen website."
+    assert outcome_index == omen_market.outcomes.index(
+        expected_buying_outcome
+    ), f"The buying outcome index should `{expected_buying_outcome}`."
+
+
+@pytest.mark.parametrize(
+    "est_p_yes, expected_outcome",
+    [
+        (Probability(0.1), "No"),
+        (Probability(0.9), "Yes"),
+    ],
+)
+def test_kelly_criterion_bet(
+    est_p_yes: Probability, expected_outcome: str, omen_market: OmenMarket
+) -> None:
+    xdai_amount, outcome_index = get_kelly_criterion_bet(
+        market=omen_market,
+        estimated_p_yes=est_p_yes,
+        max_bet=xdai_type(10),  # This significantly changes the outcome.
+    )
+    # Kelly estimates the best bet for maximizing the expected value of the logarithm of the wealth.
+    # We don't know the real best xdai_amount, but at least we know which outcome index makes sense.
+    assert outcome_index == omen_market.outcomes.index(expected_outcome)


### PR DESCRIPTION
In tidying up of the prediction-market-agent repo I found that our betting strategy code was broken and tests were failing. Have moved them over here (where it makes sense for them to live IMO) and fixed them.

Follow-up task added to make this code market-agnostic, and integrate it with `DeployableAgent.calculate_bet_amount`: https://github.com/gnosis/prediction-market-agent-tooling/issues/104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a Kelly criterion calculator for optimal bet amount determination in prediction markets.
	- Added a new strategy to calculate the optimal bet amount required to shift market probabilities to a target value.
- **Tests**
	- Enhanced testing suite with new tests for both the Kelly criterion and market moving betting strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->