### PR TITLE
Fix problem where cloud functions for failed deployments are not deleted

### DIFF
--- a/prediction_market_agent_tooling/deploy/gcp/deploy.py
+++ b/prediction_market_agent_tooling/deploy/gcp/deploy.py
@@ -15,6 +15,7 @@ from prediction_market_agent_tooling.deploy.gcp.utils import (
     gcloud_schedule_cmd,
     get_gcloud_function_uri,
     get_gcloud_id_token,
+    get_gcloud_topics,
 )
 from prediction_market_agent_tooling.tools.utils import export_requirements_from_toml
 
@@ -100,5 +101,6 @@ def run_deployed_gcp_function(function_name: str) -> requests.Response:
 
 
 def remove_deployed_gcp_function(function_name: str) -> None:
-    subprocess.run(gcloud_delete_topic_cmd(function_name), shell=True, check=True)
+    if function_name in get_gcloud_topics():
+        subprocess.run(gcloud_delete_topic_cmd(function_name), shell=True, check=True)
     subprocess.run(gcloud_delete_function_cmd(function_name), shell=True, check=True)

--- a/prediction_market_agent_tooling/deploy/gcp/utils.py
+++ b/prediction_market_agent_tooling/deploy/gcp/utils.py
@@ -66,6 +66,24 @@ def gcloud_delete_function_cmd(fname: str) -> str:
     return f"gcloud functions delete {fname} --region={get_gcloud_region()} --quiet"
 
 
+def gcloud_get_topics_cmd() -> str:
+    return "gcloud pubsub topics list --format='value(name)' | awk -F'/' '{print $NF}'"
+
+
+def get_gcloud_topics() -> list[str]:
+    return (
+        subprocess.run(
+            gcloud_get_topics_cmd(),
+            shell=True,
+            capture_output=True,
+            check=True,
+        )
+        .stdout.decode()
+        .strip()
+        .split("\n")
+    )
+
+
 def gcloud_create_topic_cmd(topic_name: str) -> str:
     return f"gcloud pubsub topics create {topic_name}"
 

--- a/tests/deploy/test_deploy.py
+++ b/tests/deploy/test_deploy.py
@@ -1,4 +1,5 @@
 import os
+import time
 from datetime import datetime
 
 from prediction_market_agent_tooling.deploy.agent_example import DeployableCoinFlipAgent
@@ -64,6 +65,9 @@ def test_gcp_deployment() -> None:
 
         deployed_agent = DeployedManifoldAgent.from_gcp_function_name(gcp_fname)
         monitor_agent(deployed_agent)
-
+    except Exception as e:
+        # Wait for the failed gcp function to have been created, so it can be removed.
+        time.sleep(10)
+        raise e
     finally:
         remove_deployed_gcp_function(gcp_fname)

--- a/tests/deploy/test_deploy.py
+++ b/tests/deploy/test_deploy.py
@@ -64,5 +64,6 @@ def test_gcp_deployment() -> None:
 
         deployed_agent = DeployedManifoldAgent.from_gcp_function_name(gcp_fname)
         monitor_agent(deployed_agent)
+
     finally:
         remove_deployed_gcp_function(gcp_fname)

--- a/tests/deploy/test_deploy.py
+++ b/tests/deploy/test_deploy.py
@@ -1,5 +1,4 @@
 import os
-import time
 from datetime import datetime
 
 from prediction_market_agent_tooling.deploy.agent_example import DeployableCoinFlipAgent
@@ -14,10 +13,6 @@ from prediction_market_agent_tooling.monitor.markets.manifold import (
     DeployedManifoldAgent,
 )
 from prediction_market_agent_tooling.monitor.monitor import monitor_agent
-from prediction_market_agent_tooling.tools.utils import (
-    get_current_git_commit_sha,
-    get_current_git_url,
-)
 
 
 def test_local_deployment() -> None:
@@ -46,7 +41,7 @@ def test_gcp_deployment() -> None:
             gcp_fname=gcp_fname,
             requirements_file=None,
             extra_deps=[
-                f"git+{get_current_git_url()}@{get_current_git_commit_sha()}",
+                # f"git+{get_current_git_url()}@{get_current_git_commit_sha()}",
             ],
             function_file=os.path.join(
                 os.path.dirname(os.path.abspath(__file__)),
@@ -65,9 +60,5 @@ def test_gcp_deployment() -> None:
 
         deployed_agent = DeployedManifoldAgent.from_gcp_function_name(gcp_fname)
         monitor_agent(deployed_agent)
-    except Exception as e:
-        # Wait for the failed gcp function to have been created, so it can be removed.
-        time.sleep(10)
-        raise e
     finally:
         remove_deployed_gcp_function(gcp_fname)

--- a/tests/deploy/test_deploy.py
+++ b/tests/deploy/test_deploy.py
@@ -13,6 +13,10 @@ from prediction_market_agent_tooling.monitor.markets.manifold import (
     DeployedManifoldAgent,
 )
 from prediction_market_agent_tooling.monitor.monitor import monitor_agent
+from prediction_market_agent_tooling.tools.utils import (
+    get_current_git_commit_sha,
+    get_current_git_url,
+)
 
 
 def test_local_deployment() -> None:
@@ -41,7 +45,7 @@ def test_gcp_deployment() -> None:
             gcp_fname=gcp_fname,
             requirements_file=None,
             extra_deps=[
-                # f"git+{get_current_git_url()}@{get_current_git_commit_sha()}",
+                f"git+{get_current_git_url()}@{get_current_git_commit_sha()}",
             ],
             function_file=os.path.join(
                 os.path.dirname(os.path.abspath(__file__)),


### PR DESCRIPTION
In test_deploy.py we test creating a gcp cloud function and topic. If this failed, the cloud function remained. This fixes that issue.

The reason the cloud function was left over:
- In the `deploy_to_gcp` implementation, it already deletes the topic if the deployment fails inside a try-except block (see [here](https://github.com/gnosis/prediction-market-agent-tooling/blob/007c6234e252a198ec0f65eed64e6f1abc90855c/prediction_market_agent_tooling/deploy/gcp/deploy.py#L79)).
- In the test, if deployment fails it calls `remove_deployed_gcp_function` (see [here](https://github.com/gnosis/prediction-market-agent-tooling/blob/main/tests/deploy/test_deploy.py#L69)) which tries to delete the topic again. This fails, so the function gets deleted.

We resolve this by checking that the topic exists before deleting it.