### PR TITLE
Fix getting manifold market when closeTime has invalid datetime timestamp

### DIFF
--- a/prediction_market_agent_tooling/markets/manifold/data_models.py
+++ b/prediction_market_agent_tooling/markets/manifold/data_models.py
@@ -2,7 +2,7 @@ import typing as t
 from datetime import datetime
 from decimal import Decimal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 from prediction_market_agent_tooling.benchmark.utils import should_not_happen
 from prediction_market_agent_tooling.gtypes import Mana, Probability
@@ -72,6 +72,17 @@ class ManifoldMarket(BaseModel):
 
     def __repr__(self) -> str:
         return f"Manifold's market: {self.question}"
+
+    @validator("closeTime", pre=True)
+    def clip_timestamp(cls, value):
+        """
+        Clip the timestamp to the maximum valid timestamp.
+        """
+        # Check value is timestamp in milliseconds
+        max_timestamp = datetime.max.timestamp() - 0.0001
+        value = min(value / 1000, max_timestamp)
+        value = datetime.fromtimestamp(value)
+        return value
 
 
 class ProfitCached(BaseModel):

--- a/prediction_market_agent_tooling/markets/manifold/data_models.py
+++ b/prediction_market_agent_tooling/markets/manifold/data_models.py
@@ -2,7 +2,7 @@ import typing as t
 from datetime import datetime
 from decimal import Decimal
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, field_validator
 
 from prediction_market_agent_tooling.benchmark.utils import should_not_happen
 from prediction_market_agent_tooling.gtypes import Mana, Probability
@@ -73,7 +73,7 @@ class ManifoldMarket(BaseModel):
     def __repr__(self) -> str:
         return f"Manifold's market: {self.question}"
 
-    @validator("closeTime", pre=True)
+    @field_validator("closeTime", mode="before")
     def clip_timestamp(cls, value: int) -> datetime:
         """
         Clip the timestamp to the maximum valid timestamp.

--- a/prediction_market_agent_tooling/markets/manifold/data_models.py
+++ b/prediction_market_agent_tooling/markets/manifold/data_models.py
@@ -74,15 +74,14 @@ class ManifoldMarket(BaseModel):
         return f"Manifold's market: {self.question}"
 
     @validator("closeTime", pre=True)
-    def clip_timestamp(cls, value):
+    def clip_timestamp(cls, value: int) -> datetime:
         """
         Clip the timestamp to the maximum valid timestamp.
         """
         # Check value is timestamp in milliseconds
         max_timestamp = datetime.max.timestamp() - 0.0001
-        value = min(value / 1000, max_timestamp)
-        value = datetime.fromtimestamp(value)
-        return value
+        value = int(min(value / 1000, max_timestamp))
+        return datetime.fromtimestamp(value)
 
 
 class ProfitCached(BaseModel):

--- a/prediction_market_agent_tooling/markets/manifold/data_models.py
+++ b/prediction_market_agent_tooling/markets/manifold/data_models.py
@@ -78,7 +78,6 @@ class ManifoldMarket(BaseModel):
         """
         Clip the timestamp to the maximum valid timestamp.
         """
-        # Check value is timestamp in milliseconds
         max_timestamp = datetime.max.timestamp() - 0.0001
         value = int(min(value / 1000, max_timestamp))
         return datetime.fromtimestamp(value)


### PR DESCRIPTION
Manifold market monitoring was failing due to a market having an invalid timestamp:
<img width="1340" alt="Screenshot 2024-03-19 at 14 30 56" src="https://github.com/gnosis/prediction-market-agent-tooling/assets/56087052/c7e33bf5-98ad-4dc5-a71f-df528c591adb">

This patches out code to work around the problem by adding a validator to the `ManifoldMarket` class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced timestamp handling in market data models to ensure validity before conversion.
	- Updated `BaseModel` import to include `field_validator` instead of `validator`.
	- Added `clip_timestamp` method to the `ManifoldMarket` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->