### PR TITLE
Fix sorting on 'closing soonest' when getting open markets from Omen

### DIFF
--- a/prediction_market_agent_tooling/markets/omen/data_models.py
+++ b/prediction_market_agent_tooling/markets/omen/data_models.py
@@ -112,6 +112,9 @@ class OmenMarket(BaseModel):
     creationTimestamp: t.Optional[int] = None
     condition: Condition
     question: Question
+    openingTimestamp: t.Optional[
+        int
+    ] = None  # Don't be fooled - this is the time that the market closes for trading, and the market question is opened on reality.eth!
 
     @property
     def answer_index(self) -> t.Optional[int]:

--- a/prediction_market_agent_tooling/markets/omen/omen.py
+++ b/prediction_market_agent_tooling/markets/omen/omen.py
@@ -70,6 +70,7 @@ class OmenAgentMarket(AgentMarket):
     collateral_token_contract_address_checksummed: ChecksumAddress
     market_maker_contract_address_checksummed: ChecksumAddress
     condition: Condition
+    finalized_time: datetime | None
 
     INVALID_MARKET_ANSWER: HexStr = HexStr(
         "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
@@ -163,11 +164,14 @@ class OmenAgentMarket(AgentMarket):
             market_maker_contract_address_checksummed=model.market_maker_contract_address_checksummed,
             resolution=model.get_resolution_enum(),
             created_time=model.creation_datetime,
-            close_time=model.finalized_datetime,
+            finalized_time=model.finalized_datetime,
             p_yes=model.p_yes,
             condition=model.condition,
             url=model.url,
             volume=wei_to_xdai(model.collateralVolume),
+            close_time=datetime.fromtimestamp(model.openingTimestamp)
+            if model.openingTimestamp
+            else None,
         )
 
     @staticmethod

--- a/prediction_market_agent_tooling/markets/omen/omen_subgraph_handler.py
+++ b/prediction_market_agent_tooling/markets/omen/omen_subgraph_handler.py
@@ -202,8 +202,7 @@ class OmenSubgraphHandler(metaclass=SingletonMeta):
             case SortBy.NEWEST:
                 sort_direction = "desc"
             case SortBy.CLOSING_SOONEST:
-                # `desc` feel unintuitive, but really if we use `asc`, we are getting markets closing in 2030, 2026, etc.
-                sort_direction = "desc"
+                sort_direction = "asc"
             case SortBy.NONE:
                 sort_direction = "desc"
             case _:

--- a/prediction_market_agent_tooling/markets/omen/omen_subgraph_handler.py
+++ b/prediction_market_agent_tooling/markets/omen/omen_subgraph_handler.py
@@ -201,8 +201,7 @@ class OmenSubgraphHandler(metaclass=SingletonMeta):
             case SortBy.NEWEST:
                 sort_direction = "desc"
             case SortBy.CLOSING_SOONEST:
-                # `desc` feel unintuitive, but really if we use `asc`, we are getting markets closing in 2030, 2026, etc.
-                sort_direction = "desc"
+                sort_direction = "asc"
             case SortBy.NONE:
                 sort_direction = "desc"
             case _:
@@ -243,8 +242,11 @@ class OmenSubgraphHandler(metaclass=SingletonMeta):
         )
 
         sort_direction = self._build_sort_direction(sort_by)
+
         markets = self.trades_subgraph.Query.fixedProductMarketMakers(
-            orderBy=self.trades_subgraph.FixedProductMarketMaker.creationTimestamp,
+            orderBy=self.trades_subgraph.FixedProductMarketMaker.openingTimestamp
+            if sort_by == SortBy.CLOSING_SOONEST
+            else self.trades_subgraph.FixedProductMarketMaker.creationTimestamp,
             orderDirection=sort_direction,
             first=(
                 limit if limit else sys.maxsize

--- a/prediction_market_agent_tooling/markets/omen/omen_subgraph_handler.py
+++ b/prediction_market_agent_tooling/markets/omen/omen_subgraph_handler.py
@@ -172,6 +172,7 @@ class OmenSubgraphHandler(metaclass=SingletonMeta):
         if resolved is not None:
             if resolved:
                 where_stms["resolutionTimestamp_not"] = None
+                where_stms["currentAnswer_not"] = self.INVALID_ANSWER
             else:
                 where_stms["resolutionTimestamp"] = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prediction-market-agent-tooling"
-version = "0.9.1"
+version = "0.9.2"
 description = "Tools to benchmark, deploy and monitor prediction market agents."
 authors = ["Gnosis"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prediction-market-agent-tooling"
-version = "0.9.0"
+version = "0.9.1"
 description = "Tools to benchmark, deploy and monitor prediction market agents."
 authors = ["Gnosis"]
 readme = "README.md"

--- a/tests/markets/omen/test_omen.py
+++ b/tests/markets/omen/test_omen.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import numpy as np
 import pytest
@@ -161,7 +161,7 @@ def test_omen_market_close_time() -> None:
     - close time is in the future
     - close time is in ascending order
     """
-    time_now = utcnow()
+    time_now = datetime.now()
     markets = [
         OmenAgentMarket.from_data_model(m)
         for m in get_omen_binary_markets(

--- a/tests/markets/omen/test_omen.py
+++ b/tests/markets/omen/test_omen.py
@@ -155,7 +155,26 @@ def create_market_fund_market_remove_funding() -> None:
 
 
 def test_omen_market_close_time() -> None:
-    market = OmenAgentMarket.from_data_model(pick_binary_market())
-    assert (
-        market.close_time > market.created_time
-    ), "Market close time should be after open time."
+    """
+    Get open markets sorted by 'closing_soonest'. Verify that:
+    - close time is after open time
+    - close time is in the future
+    - close time is in ascending order
+    """
+    time_now = utcnow()
+    markets = [
+        OmenAgentMarket.from_data_model(m)
+        for m in get_omen_binary_markets(
+            limit=100,
+            sort_by=SortBy.CLOSING_SOONEST,
+            filter_by=FilterBy.OPEN,
+        )
+    ]
+    for market in markets:
+        assert (
+            market.close_time > market.created_time
+        ), "Market close time should be after open time."
+        assert (
+            market.close_time >= time_now
+        ), "Market close time should be in the future."
+        time_now = market.close_time  # Ensure close time is in ascending order

--- a/tests/markets/omen/test_omen.py
+++ b/tests/markets/omen/test_omen.py
@@ -152,3 +152,10 @@ def create_market_fund_market_remove_funding() -> None:
         - Assert amount in xDAI is reflected in user's balance
     """
     assert True
+
+
+def test_omen_market_close_time() -> None:
+    market = OmenAgentMarket.from_data_model(pick_binary_market())
+    assert (
+        market.close_time > market.created_time
+    ), "Market close time should be after open time."

--- a/tests/markets/omen/test_omen.py
+++ b/tests/markets/omen/test_omen.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import numpy as np
 import pytest
@@ -6,7 +6,7 @@ from eth_typing import HexAddress, HexStr
 from loguru import logger
 
 from prediction_market_agent_tooling.config import APIKeys
-from prediction_market_agent_tooling.gtypes import xdai_type
+from prediction_market_agent_tooling.gtypes import DatetimeWithTimezone, xdai_type
 from prediction_market_agent_tooling.markets.agent_market import FilterBy, SortBy
 from prediction_market_agent_tooling.markets.omen.omen import (
     OMEN_FALSE_OUTCOME,
@@ -161,7 +161,7 @@ def test_omen_market_close_time() -> None:
     - close time is in the future
     - close time is in ascending order
     """
-    time_now = datetime.now()
+    time_now = utcnow()
     markets = [
         OmenAgentMarket.from_data_model(m)
         for m in get_omen_binary_markets(
@@ -177,4 +177,6 @@ def test_omen_market_close_time() -> None:
         assert (
             market.close_time >= time_now
         ), "Market close time should be in the future."
-        time_now = market.close_time  # Ensure close time is in ascending order
+        time_now = DatetimeWithTimezone(
+            market.close_time
+        )  # Ensure close time is in ascending order

--- a/tests/markets/test_betting_strategies.py
+++ b/tests/markets/test_betting_strategies.py
@@ -111,6 +111,7 @@ def test_minimum_bet_to_win(
             condition=Condition(id=HexBytes("0x123"), outcomeSlotCount=2),
             url="url",
             volume=None,
+            finalized_time=None,
         ),
     )
     assert (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new attribute to track market opening times more accurately.
	- Enhanced sorting functionality for markets to prioritize by closing time.

- **Bug Fixes**
	- Adjusted market close time handling to improve accuracy in market status.

- **Tests**
	- Added tests to ensure correct handling of market close times and betting strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->