### PR TITLE
Filter open omen markets by non-zero liquidity

### DIFF
--- a/prediction_market_agent_tooling/markets/omen/data_models.py
+++ b/prediction_market_agent_tooling/markets/omen/data_models.py
@@ -99,7 +99,12 @@ class OmenMarket(BaseModel):
     creator: HexAddress
     category: str
     collateralVolume: Wei
-    liquidityMeasure: Wei
+    # Note: there are two similar parameters relating to liquidity:
+    # liquidityParameter and liquidityMeasure. The former appears to match most
+    # closely with the liquidity returned when calling the contract directly
+    # (see OmenAgentMarket.get_liquidity). So we can use it e.g. for filtering
+    # markets, but until better understood, please call the contract directly.
+    liquidityParameter: Wei
     usdVolume: USD
     collateralToken: HexAddress
     outcomes: list[str]

--- a/prediction_market_agent_tooling/markets/omen/omen.py
+++ b/prediction_market_agent_tooling/markets/omen/omen.py
@@ -185,7 +185,7 @@ class OmenAgentMarket(AgentMarket):
         if filter_by == FilterBy.OPEN:
             # We assume here that we are only interested in markets that
             # we can trade on, i.e. ones with non-zero liquidity.
-            liquidity_bigger_than = (wei_type(0),)
+            liquidity_bigger_than = wei_type(0)
         else:
             liquidity_bigger_than = None
 

--- a/prediction_market_agent_tooling/markets/omen/omen.py
+++ b/prediction_market_agent_tooling/markets/omen/omen.py
@@ -182,6 +182,13 @@ class OmenAgentMarket(AgentMarket):
         created_after: t.Optional[datetime] = None,
         excluded_questions: set[str] | None = None,
     ) -> list[AgentMarket]:
+        if filter_by == FilterBy.OPEN:
+            # We assume here that we are only interested in markets that
+            # we can trade on, i.e. ones with non-zero liquidity.
+            liquidity_bigger_than = (wei_type(0),)
+        else:
+            liquidity_bigger_than = None
+
         return [
             OmenAgentMarket.from_data_model(m)
             for m in get_omen_binary_markets(
@@ -190,6 +197,7 @@ class OmenAgentMarket(AgentMarket):
                 created_after=created_after,
                 filter_by=filter_by,
                 excluded_questions=excluded_questions,
+                liquidity_bigger_than=liquidity_bigger_than,
             )
         ]
 

--- a/prediction_market_agent_tooling/markets/omen/omen_replicate.py
+++ b/prediction_market_agent_tooling/markets/omen/omen_replicate.py
@@ -178,11 +178,11 @@ def omen_unfund_replicated_known_markets_tx(
             )
         ):
             logger.info(
-                f"[{idx+1}/{len(markets)}] Skipping unfunding of `{market.liquidityMeasure=} {market.question=}  {market.url=}`, because it's not saturated yet, `{market.p_yes=}`."
+                f"[{idx+1}/{len(markets)}] Skipping unfunding of `{market.liquidityParameter=} {market.question=}  {market.url=}`, because it's not saturated yet, `{market.p_yes=}`."
             )
             continue
         logger.info(
-            f"[{idx+1}/{len(markets)}] Unfunding market `{market.liquidityMeasure=} {market.question=} {market.url=}`."
+            f"[{idx+1}/{len(markets)}] Unfunding market `{market.liquidityParameter=} {market.question=} {market.url=}`."
         )
         omen_remove_fund_market_tx(
             market=OmenAgentMarket.from_data_model(market),

--- a/prediction_market_agent_tooling/markets/omen/omen_subgraph_handler.py
+++ b/prediction_market_agent_tooling/markets/omen/omen_subgraph_handler.py
@@ -96,7 +96,7 @@ class OmenSubgraphHandler(metaclass=SingletonMeta):
             markets_field.creator,
             markets_field.collateralVolume,
             markets_field.usdVolume,
-            markets_field.liquidityMeasure,
+            markets_field.liquidityParameter,
             markets_field.collateralToken,
             markets_field.outcomes,
             markets_field.outcomeTokenAmounts,
@@ -152,7 +152,7 @@ class OmenSubgraphHandler(metaclass=SingletonMeta):
             where_stms["openingTimestamp_lt"] = to_int_timestamp(opened_before)
 
         if liquidity_bigger_than is not None:
-            where_stms["liquidityMeasure_gt"] = liquidity_bigger_than
+            where_stms["liquidityParameter_gt"] = liquidity_bigger_than
 
         if condition_id_in is not None:
             where_stms["condition_"]["id_in"] = [x.hex() for x in condition_id_in]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prediction-market-agent-tooling"
-version = "0.9.2"
+version = "0.9.3"
 description = "Tools to benchmark, deploy and monitor prediction market agents."
 authors = ["Gnosis"]
 readme = "README.md"

--- a/tests/markets/omen/test_omen.py
+++ b/tests/markets/omen/test_omen.py
@@ -180,3 +180,19 @@ def test_omen_market_close_time() -> None:
         time_now = DatetimeWithTimezone(
             market.close_time
         )  # Ensure close time is in ascending order
+
+
+def test_market_liquidity() -> None:
+    """
+    Get open markets sorted by 'closing soonest'. Verify that liquidity is
+    greater than 0
+    """
+    markets = OmenAgentMarket.get_binary_markets(
+        limit=10,
+        sort_by=SortBy.CLOSING_SOONEST,
+        filter_by=FilterBy.OPEN,
+    )
+    for market in markets:
+        assert (
+            market.get_liquidity_in_xdai() > 0
+        ), "Market liquidity should be greater than 0."

--- a/tests/markets/omen/test_omen.py
+++ b/tests/markets/omen/test_omen.py
@@ -193,6 +193,7 @@ def test_market_liquidity() -> None:
         filter_by=FilterBy.OPEN,
     )
     for market in markets:
+        assert type(market) == OmenAgentMarket
         assert (
             market.get_liquidity_in_xdai() > 0
         ), "Market liquidity should be greater than 0."

--- a/tests/markets/test_betting_strategies.py
+++ b/tests/markets/test_betting_strategies.py
@@ -77,7 +77,7 @@ def omen_market() -> OmenMarket:
             isPendingArbitration=False,
             data="...",
         ),
-        liquidityMeasure=Wei(10),
+        liquidityParameter=Wei(10),
     )
 
 


### PR DESCRIPTION
Now `OmenAgentMarket.get_binary_markets(filter_by=FilterBy.OPEN, sort_by=SortBy.CLOSING_SOONEST)` only returns markets that have not had their liquidity removed by the market-maker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated terminology from `liquidityMeasure` to `liquidityParameter` across various components for clarity.
- **New Features**
	- Enhanced filtering in `get_binary_markets` to dynamically set liquidity parameters based on user input.
- **Tests**
	- Adjusted test cases to reflect the updated parameter naming convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->