### PR TITLE
Add AgentMarket.get_positions

### DIFF
--- a/prediction_market_agent_tooling/gtypes.py
+++ b/prediction_market_agent_tooling/gtypes.py
@@ -28,6 +28,7 @@ xDai = NewType("xDai", float)
 GNO = NewType("GNO", float)
 ABI = NewType("ABI", str)
 OmenOutcomeToken = NewType("OmenOutcomeToken", int)
+OutcomeStr = NewType("OutcomeStr", str)
 Probability = NewType("Probability", float)
 Mana = NewType("Mana", float)  # Manifold's "currency"
 USDC = NewType("USDC", float)

--- a/prediction_market_agent_tooling/markets/agent_market.py
+++ b/prediction_market_agent_tooling/markets/agent_market.py
@@ -8,6 +8,7 @@ from prediction_market_agent_tooling.gtypes import Probability
 from prediction_market_agent_tooling.markets.data_models import (
     BetAmount,
     Currency,
+    Position,
     Resolution,
     TokenAmount,
 )
@@ -151,4 +152,10 @@ class AgentMarket(BaseModel):
         return (self.p_yes - self.boolean_outcome) ** 2
 
     def get_token_balance(self, user_id: str, outcome: str) -> TokenAmount:
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def get_positions(self, user_id: str) -> list[Position]:
+        """
+        Get all non-zero positions a user has in any market.
+        """
         raise NotImplementedError("Subclasses must implement this method")

--- a/prediction_market_agent_tooling/markets/data_models.py
+++ b/prediction_market_agent_tooling/markets/data_models.py
@@ -4,6 +4,8 @@ from typing import TypeAlias
 
 from pydantic import BaseModel
 
+from prediction_market_agent_tooling.gtypes import OutcomeStr
+
 
 class Currency(str, Enum):
     xDai = "xDai"
@@ -42,3 +44,15 @@ class ResolvedBet(Bet):
     @property
     def is_correct(self) -> bool:
         return self.outcome == self.market_outcome
+
+
+class Position(BaseModel):
+    market_id: str
+    amounts: dict[OutcomeStr, TokenAmount]
+
+    def __str__(self) -> str:
+        amounts_str = ", ".join(
+            f"{amount.amount} '{outcome}' tokens"
+            for outcome, amount in self.amounts.items()
+        )
+        return f"Position for market id {self.market_id}: {amounts_str}"

--- a/prediction_market_agent_tooling/markets/omen/data_models.py
+++ b/prediction_market_agent_tooling/markets/omen/data_models.py
@@ -90,6 +90,24 @@ class OmenPosition(BaseModel):
     indexSets: list[int]
 
     @property
+    def condition_id(self) -> HexBytes:
+        # I didn't find any example where this wouldn't hold, but keeping this double-check here in case something changes in the future.
+        # May be the case if the market is created with multiple oracles.
+        if len(self.conditionIds) != 1:
+            raise ValueError(
+                f"Bug in the logic, please investigate why zero or multiple conditions are returned for position {self.id=}"
+            )
+        return self.conditionIds[0]
+
+    @property
+    def index_set(self) -> int:
+        if len(self.indexSets) != 1:
+            raise ValueError(
+                f"Bug in the logic, please investigate why zero or multiple index sets are returned for position {self.id=}"
+            )
+        return self.indexSets[0]
+
+    @property
     def collateral_token_contract_address_checksummed(self) -> ChecksumAddress:
         return Web3.to_checksum_address(self.collateralTokenAddress)
 

--- a/prediction_market_agent_tooling/markets/omen/omen.py
+++ b/prediction_market_agent_tooling/markets/omen/omen.py
@@ -1,3 +1,4 @@
+import sys
 import typing as t
 from datetime import datetime
 
@@ -10,6 +11,7 @@ from prediction_market_agent_tooling.gtypes import (
     ChecksumAddress,
     HexAddress,
     HexStr,
+    OutcomeStr,
     PrivateKey,
     Wei,
     wei_type,
@@ -24,6 +26,7 @@ from prediction_market_agent_tooling.markets.agent_market import (
 from prediction_market_agent_tooling.markets.data_models import (
     BetAmount,
     Currency,
+    Position,
     TokenAmount,
 )
 from prediction_market_agent_tooling.markets.omen.data_models import (
@@ -33,6 +36,7 @@ from prediction_market_agent_tooling.markets.omen.data_models import (
     Condition,
     OmenBet,
     OmenMarket,
+    OmenUserPosition,
 )
 from prediction_market_agent_tooling.markets.omen.omen_contracts import (
     OMEN_DEFAULT_MARKET_FEE,
@@ -48,6 +52,7 @@ from prediction_market_agent_tooling.markets.omen.omen_subgraph_handler import (
     OmenSubgraphHandler,
 )
 from prediction_market_agent_tooling.tools.balances import get_balances
+from prediction_market_agent_tooling.tools.hexbytes_custom import HexBytes
 from prediction_market_agent_tooling.tools.utils import check_not_none
 from prediction_market_agent_tooling.tools.web3_utils import (
     add_fraction,
@@ -57,7 +62,6 @@ from prediction_market_agent_tooling.tools.web3_utils import (
     xdai_to_wei,
 )
 
-MAX_NUMBER_OF_MARKETS_FOR_SUBGRAPH_RETRIEVAL = 1000
 OMEN_DEFAULT_REALITIO_BOND_VALUE = xdai_type(0.01)
 
 
@@ -226,6 +230,12 @@ class OmenAgentMarket(AgentMarket):
     def get_index_set(self, outcome: str) -> int:
         return self.get_outcome_index(outcome) + 1
 
+    def index_set_to_outcome_index(cls, index_set: int) -> int:
+        return index_set - 1
+
+    def index_set_to_outcome_str(cls, index_set: int) -> str:
+        return cls.get_outcome_str(cls.index_set_to_outcome_index(index_set))
+
     def get_token_balance(self, user_id: str, outcome: str) -> TokenAmount:
         index_set = self.get_index_set(outcome)
         balances = get_conditional_tokens_balance_for_market(
@@ -235,6 +245,56 @@ class OmenAgentMarket(AgentMarket):
             amount=wei_to_xdai(balances[index_set]),
             currency=Currency.xDai,
         )
+
+    @classmethod
+    def get_positions(cls, user_id: str) -> list[Position]:
+        sgh = OmenSubgraphHandler()
+        omen_positions = sgh.get_user_positions(
+            better_address=Web3.to_checksum_address(user_id),
+            total_balance_bigger_than=wei_type(0),
+        )
+
+        # Sort positions and corresponding markets by condition_id
+        omen_positions_dict: dict[HexBytes, list[OmenUserPosition]] = {}
+        for omen_position in omen_positions:
+            condition_id = omen_position.position.condition_id
+            omen_positions_dict.setdefault(condition_id, []).append(omen_position)
+
+        omen_markets: dict[HexBytes, OmenMarket] = {
+            m.condition.id: m
+            for m in sgh.get_omen_binary_markets(
+                limit=sys.maxsize,
+                condition_id_in=list(omen_positions_dict.keys()),
+            )
+        }
+        if len(omen_markets) != len(omen_positions_dict):
+            raise ValueError(
+                f"Number of condition ids for markets {len(omen_markets)} and positions {len(omen_positions_dict)} are not equal."
+            )
+
+        positions = []
+        for condition_id, omen_positions in omen_positions_dict.items():
+            market = cls.from_data_model(omen_markets[condition_id])
+            amounts: dict[OutcomeStr, TokenAmount] = {}
+            for omen_position in omen_positions:
+                outecome_str = market.index_set_to_outcome_str(
+                    omen_position.position.index_set
+                )
+
+                # Validate that outcomes are unique for a given condition_id.
+                if outecome_str in amounts:
+                    raise ValueError(
+                        f"Outcome {outecome_str} already exists in {amounts=}"
+                    )
+
+                amounts[outecome_str] = TokenAmount(
+                    amount=wei_to_xdai(omen_position.totalBalance),
+                    currency=Currency.xDai,
+                )
+
+            positions.append(Position(market_id=market.id, amounts=amounts))
+
+        return positions
 
 
 def pick_binary_market(
@@ -672,12 +732,7 @@ def redeem_from_all_user_positions(
     )
 
     for index, user_position in enumerate(user_positions):
-        # I didn't find any example where this wouldn't hold, but keeping this double-check here in case something changes in the future.
-        if len(user_position.position.conditionIds) != 1:
-            raise ValueError(
-                f"Bug in the logic, please investigate why zero or multiple conditions are returned for {user_position.id=}"
-            )
-        condition_id = user_position.position.conditionIds[0]
+        condition_id = user_position.position.condition_id
 
         if not conditional_token_contract.is_condition_resolved(condition_id):
             logger.info(

--- a/tests/markets/omen/test_omen.py
+++ b/tests/markets/omen/test_omen.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 import numpy as np
 import pytest
+from eth_account import Account
 from eth_typing import HexAddress, HexStr
 from loguru import logger
 from web3 import Web3
@@ -225,3 +226,63 @@ def test_balance_for_user_in_market() -> None:
     )
     assert balance_no.currency == Currency.xDai
     assert float(balance_no.amount) == 0
+
+
+"""
+
+def test_get_omen_markets_by_condition_ids(
+    omen_subgraph_handler: OmenSubgraphHandler,
+) -> None:
+    condition_ids = [
+        HexBytes("0x9c7711bee0902cc8e6838179058726a7ba769cc97d4d0ea47b31370d2d7a117b")
+    ]
+    expected_market_title = (
+        "Will the Federal Reserve cut interest rates on 28 March 2024?"
+    )
+    markets = omen_subgraph_handler.get_omen_markets_by_condition_ids(condition_ids)
+    assert len(markets) == 1
+    assert markets[0].title == expected_market_title
+"""
+
+
+def test_get_positions_0() -> None:
+    """
+    Create a new account and verify that there are no positions for the account
+    """
+    user_id = Account.create().address
+    positions = OmenAgentMarket.get_positions(user_id=user_id)
+    assert len(positions) == 0
+
+
+# @pytest.mark.skipif(not RUN_PAID_TESTS, reason="This test costs money to run.")
+# def test_get_positions_1() -> None:
+#     """
+#     Create a new account, place a bet and verify that the position is returned
+#     """
+#     account = Account.create()
+#     keys = APIKeys(BET_FROM_PRIVATE_KEY=account.key.hex())
+#     market = OmenAgentMarket.get_binary_markets(
+#         limit=1,
+#         sort_by=SortBy.CLOSING_SOONEST,
+#         filter_by=FilterBy.OPEN,
+#     )[0]
+
+#     yes_bet_amount = market.get_tiny_bet_amount()
+#     no_bet_amount = market.get_tiny_bet_amount()
+#     no_bet_amount.amount = no_bet_amount.amount * 2
+
+#     market.place_bet(outcome=True, amount=yes_bet_amount)
+#     market.place_bet(outcome=False, amount=yes_bet_amount)
+#     yes_token_balance = market.get_token_balance(
+#         user_id=account.address, outcome=OMEN_TRUE_OUTCOME
+#     )
+#     no_token_balance = market.get_token_balance(
+#         user_id=account.address, outcome=OMEN_FALSE_OUTCOME
+#     )
+
+#     breakpoint()
+#     positions = OmenAgentMarket.get_positions(user_id=account.address)
+#     assert len(positions) == 1
+#     assert positions[0].market_id == market.id
+#     assert positions[0].amounts[OMEN_TRUE_OUTCOME].amount == yes_token_balance
+#     assert positions[0].amounts[OMEN_FALSE_OUTCOME].amount == no_token_balance


### PR DESCRIPTION
Usage:
```
from prediction_market_agent_tooling.config import APIKeys
from prediction_market_agent_tooling.markets.omen.omen import OmenAgentMarket

positions = OmenAgentMarket.get_positions(user_id=APIKeys().bet_from_address)
for p in positions:
    print(p)
```
Produces:
```
Position for market id 0x61aea286bf843351ae1fff1b68f1ed3cea37ccb0: 3.9201882281485e-05 'No' tokens
Position for market id 0x59d938c7cbf7c970a63d0d96fee4f2ce72e70866: 1.6651164236599e-05 'Yes' tokens, 2.3818060369711e-05 'No' tokens
Position for market id 0xc1ac6a834eb5aed2d3df30bcd36efdd350f04362: 1.4981719567727e-05 'Yes' tokens, 2.3228428502297e-05 'No' tokens
Position for market id 0x80ee8941c0dacb7d415a2eb0f65aa6d72f64b64b: 4.8234756855848e-05 'Yes' tokens
Position for market id 0x415e1187c68880c9edd83462f4233a05913b2e92: 1.9504892057833e-05 'No' tokens, 1.9695098897506e-05 'Yes' tokens
Position for market id 0xf692eedff342a0de902b45c27e0e2d4454d80c92: 2.5321118633481e-05 'No' tokens
Position for market id 0xbaa1873436c3dc7feaa9f8369f53a6bbd44fb3e5: 1.2788154148868e-05 'Yes' tokens, 7.3729983411822e-05 'No' tokens
Position for market id 0xc066f2c4c5aa9e7ad4ae3f348aec0e679d3850d2: 2.4262516466771e-05 'No' tokens
...
```