### PR TITLE
Add ability to filter positions by whether they can be sold

### DIFF
--- a/prediction_market_agent_tooling/markets/agent_market.py
+++ b/prediction_market_agent_tooling/markets/agent_market.py
@@ -158,7 +158,7 @@ class AgentMarket(BaseModel):
         raise NotImplementedError("Subclasses must implement this method")
 
     def has_liquidity(self) -> bool:
-        return self.get_liquidity() > 0
+        return self.get_liquidity().amount > 0
 
     def has_successful_resolution(self) -> bool:
         return self.resolution in [Resolution.YES, Resolution.NO]
@@ -184,7 +184,7 @@ class AgentMarket(BaseModel):
         raise NotImplementedError("Subclasses must implement this method")
 
     @classmethod
-    def get_positions(cls, user_id: str, liquid_only: bool) -> list[Position]:
+    def get_positions(cls, user_id: str, liquid_only: bool = False) -> list[Position]:
         """
         Get all non-zero positions a user has in any market.
 

--- a/prediction_market_agent_tooling/markets/omen/omen.py
+++ b/prediction_market_agent_tooling/markets/omen/omen.py
@@ -315,7 +315,7 @@ class OmenAgentMarket(AgentMarket):
         )
 
     @classmethod
-    def get_liquid_positions(cls, user_id: str, liquid_only: bool) -> list[Position]:
+    def get_positions(cls, user_id: str, liquid_only: bool = False) -> list[Position]:
         sgh = OmenSubgraphHandler()
         omen_positions = sgh.get_user_positions(
             better_address=Web3.to_checksum_address(user_id),

--- a/prediction_market_agent_tooling/markets/omen/omen.py
+++ b/prediction_market_agent_tooling/markets/omen/omen.py
@@ -117,11 +117,17 @@ class OmenAgentMarket(AgentMarket):
             else None
         )
 
-    def get_liquidity(self) -> Wei:
+    def get_liquidity_in_wei(self) -> Wei:
         return self.get_contract().totalSupply()
 
     def get_liquidity_in_xdai(self) -> xDai:
-        return wei_to_xdai(self.get_liquidity())
+        return wei_to_xdai(self.get_liquidity_in_wei())
+
+    def get_liquidity(self) -> TokenAmount:
+        return TokenAmount(
+            amount=self.get_liquidity_in_xdai(),
+            currency=Currency.xDai,
+        )
 
     def get_tiny_bet_amount(self) -> BetAmount:
         return BetAmount(amount=0.00001, currency=self.currency)
@@ -133,6 +139,10 @@ class OmenAgentMarket(AgentMarket):
         omen_auto_deposit: bool = True,
         web3: Web3 | None = None,
     ) -> None:
+        if not self.can_be_traded():
+            raise ValueError(
+                f"Market {self.id} is not open for trading. Cannot place bet."
+            )
         if amount.currency != self.currency:
             raise ValueError(f"Omen bets are made in xDai. Got {amount.currency}.")
         amount_xdai = xDai(amount.amount)
@@ -148,6 +158,10 @@ class OmenAgentMarket(AgentMarket):
     def sell_tokens(
         self, outcome: bool, amount: TokenAmount, auto_withdraw: bool = True
     ) -> None:
+        if not self.can_be_traded():
+            raise ValueError(
+                f"Market {self.id} is not open for trading. Cannot sell tokens."
+            )
         binary_omen_sell_outcome_tx(
             api_keys=APIKeys(),
             amount=xDai(amount.amount),
@@ -301,7 +315,7 @@ class OmenAgentMarket(AgentMarket):
         )
 
     @classmethod
-    def get_positions(cls, user_id: str) -> list[Position]:
+    def get_liquid_positions(cls, user_id: str, liquid_only: bool) -> list[Position]:
         sgh = OmenSubgraphHandler()
         omen_positions = sgh.get_user_positions(
             better_address=Web3.to_checksum_address(user_id),
@@ -329,6 +343,11 @@ class OmenAgentMarket(AgentMarket):
         positions = []
         for condition_id, omen_positions in omen_positions_dict.items():
             market = cls.from_data_model(omen_markets[condition_id])
+
+            # Skip markets that cannot be traded if `liquid_only`` is True.
+            if liquid_only and not market.can_be_traded():
+                continue
+
             amounts: dict[OutcomeStr, TokenAmount] = {}
             for omen_position in omen_positions:
                 outecome_str = market.index_set_to_outcome_str(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prediction-market-agent-tooling"
-version = "0.27.0"
+version = "0.28.0"
 description = "Tools to benchmark, deploy and monitor prediction market agents."
 authors = ["Gnosis"]
 readme = "README.md"

--- a/tests/markets/omen/test_omen.py
+++ b/tests/markets/omen/test_omen.py
@@ -80,9 +80,13 @@ def test_market_liquidity() -> None:
     )
     for market in markets:
         assert type(market) == OmenAgentMarket
-        assert (
-            market.get_liquidity_in_xdai() > 0
-        ), "Market liquidity should be greater than 0."
+        assert market.has_liquidity()
+
+
+def test_can_be_traded() -> None:
+    id = "0x0020d13c89140b47e10db54cbd53852b90bc1391"  # A known resolved market
+    market = OmenAgentMarket.get_binary_market(id)
+    assert not market.can_be_traded()
 
 
 def test_get_binary_market() -> None:
@@ -120,7 +124,11 @@ def test_get_positions_1() -> None:
         "0x2DD9f5678484C1F59F97eD334725858b938B4102"
     )
     positions = OmenAgentMarket.get_positions(user_id=user_address)
-    assert len(positions)
+    liquid_positions = OmenAgentMarket.get_positions(
+        user_id=user_address,
+        liquid_only=True,
+    )
+    assert len(positions) > len(liquid_positions)
 
     # Pick a single position to test, otherwise it can be very slow
     position = positions[0]


### PR DESCRIPTION
Add `liquid_only` boolean arg to `AgentMarket.get_positions` to optionally filter for positions that can be sold.

Also improve the error message when trying to buy/sell tokens in a market that has closed or has zero liquidity:

Before:
```ValueError: non-hexadecimal number found in fromhex() arg at position 0```

After:
```ValueError: Market 0x555b5fdfd3fec7db7d50afd1c970d798072d80f8 is not open for trading. Cannot place bet.```

Fixes https://github.com/gnosis/prediction-market-agent-tooling/issues/240