### PR TITLE
OmenAgentMarket.sell_tokens gets token pool balance dynamically

### DIFF
--- a/tests/markets/test_betting_strategies.py
+++ b/tests/markets/test_betting_strategies.py
@@ -118,7 +118,6 @@ def test_minimum_bet_to_win(
             url="url",
             volume=None,
             finalized_time=None,
-            outcome_token_amounts=[OmenOutcomeToken(2), OmenOutcomeToken(3)],
             fee=0.02,
         ),
     )

--- a/tests_integration/markets/omen/test_omen.py
+++ b/tests_integration/markets/omen/test_omen.py
@@ -258,4 +258,4 @@ def test_omen_buy_and_sell_outcome(
 
     # Check that we have sold our entire stake in the market.
     remaining_tokens = get_market_outcome_tokens()
-    assert np.isclose(remaining_tokens.amount, 0, atol=1e-3)
+    assert np.isclose(remaining_tokens.amount, 0, atol=1e-6)

--- a/tests_integration/markets/omen/test_omen.py
+++ b/tests_integration/markets/omen/test_omen.py
@@ -249,9 +249,6 @@ def test_omen_buy_and_sell_outcome(
     outcome_tokens = get_market_outcome_tokens()
     assert outcome_tokens.amount > 0
 
-    # TODO hack to get test to pass. https://github.com/gnosis/prediction-market-agent-tooling/issues/271
-    market.fee = 0.0
-
     market.sell_tokens(
         outcome=outcome,
         amount=outcome_tokens,

--- a/tests_integration/markets/omen/test_omen.py
+++ b/tests_integration/markets/omen/test_omen.py
@@ -249,6 +249,9 @@ def test_omen_buy_and_sell_outcome(
     outcome_tokens = get_market_outcome_tokens()
     assert outcome_tokens.amount > 0
 
+    # TODO hack to get test to pass. https://github.com/gnosis/prediction-market-agent-tooling/issues/271
+    market.fee = 0.0
+
     market.sell_tokens(
         outcome=outcome,
         amount=outcome_tokens,
@@ -258,4 +261,4 @@ def test_omen_buy_and_sell_outcome(
 
     # Check that we have sold our entire stake in the market.
     remaining_tokens = get_market_outcome_tokens()
-    assert np.isclose(remaining_tokens.amount, 0, atol=5e-3)
+    assert np.isclose(remaining_tokens.amount, 0, atol=1e-3)


### PR DESCRIPTION
... instead of saving it at constriction time.

This fixes an issue where you could do
```
market = get_market()
market.buy_tokens(amount) # Pool balance is now incorrect!
market.sell_tokens(num_tokens) # num_tokens -> collateral calculation is now wrong
```

This therefore fixes the flaky tests_integration/markets/omen/test_omen.py::test_omen_buy_and_sell_outcome