### PR TITLE
Make balance check in test_omen_buy_and_sell_outcome less strict

### DIFF
--- a/tests_integration/markets/omen/test_omen.py
+++ b/tests_integration/markets/omen/test_omen.py
@@ -263,7 +263,7 @@ def test_omen_buy_and_sell_outcome(
 
     # Check that we have sold our entire stake in the market.
     remaining_tokens = get_market_outcome_tokens()
-    assert np.isclose(remaining_tokens.amount, 0, atol=1e-6)
+    assert np.isclose(remaining_tokens.amount, 0, atol=1e-5)
 
 
 def test_place_bet_with_autodeposit(


### PR DESCRIPTION
It's causing failures (see e.g. https://github.com/gnosis/prediction-market-agent-tooling/actions/runs/9546341587/job/26309539429?pr=276)