### PR TITLE
Add utc timezones to OmenBet timestamps

### DIFF
--- a/prediction_market_agent_tooling/markets/omen/data_models.py
+++ b/prediction_market_agent_tooling/markets/omen/data_models.py
@@ -1,6 +1,7 @@
 import typing as t
 from datetime import datetime
 
+import pytz
 from pydantic import BaseModel
 from web3 import Web3
 
@@ -218,7 +219,7 @@ class OmenMarket(BaseModel):
 
     @property
     def opening_datetime(self) -> datetime:
-        return datetime.fromtimestamp(self.openingTimestamp)
+        return datetime.fromtimestamp(self.openingTimestamp, tz=pytz.UTC)
 
     @property
     def close_time(self) -> datetime:
@@ -400,7 +401,7 @@ class OmenBet(BaseModel):
 
     @property
     def creation_datetime(self) -> datetime:
-        return datetime.fromtimestamp(self.creationTimestamp)
+        return datetime.fromtimestamp(self.creationTimestamp, tz=pytz.UTC)
 
     @property
     def boolean_outcome(self) -> bool:

--- a/prediction_market_agent_tooling/tools/langfuse_client_utils.py
+++ b/prediction_market_agent_tooling/tools/langfuse_client_utils.py
@@ -6,6 +6,7 @@ from langfuse import Langfuse
 from langfuse.client import TraceWithDetails
 from pydantic import BaseModel
 
+from prediction_market_agent_tooling.loggers import logger
 from prediction_market_agent_tooling.markets.data_models import (
     PlacedTrade,
     ProbabilisticAnswer,
@@ -146,9 +147,21 @@ def get_trace_for_bet(
     else:
         # In-case there are multiple traces for the same market, get the closest
         # trace to the bet
+        bet_timestamp = add_utc_timezone_validator(bet.created_time)
         closest_trace_index = get_closest_datetime_from_list(
-            add_utc_timezone_validator(bet.created_time),
+            bet_timestamp,
             [t.timestamp for t in traces_for_bet],
         )
+
+        # Sanity check: Let's say the upper bound for time between
+        # `agent.process_market` being called and the bet being placed is 20
+        # minutes
+        candidate_trace = traces_for_bet[closest_trace_index]
+        if abs(candidate_trace.timestamp - bet_timestamp).total_seconds() > 1200:
+            logger.info(
+                f"Closest trace to bet has timestamp {candidate_trace.timestamp}, "
+                f"but bet was created at {bet_timestamp}. Not matching"
+            )
+            return None
 
         return traces_for_bet[closest_trace_index]


### PR DESCRIPTION
Otherwise bet timezones are one hour out, and you get a bunch of no-matches, e.g.:
```
Closest trace to bet has timestamp 2024-09-13 09:02:03.241000+00:00, but bet was created at 2024-09-13 10:02:30+00:00. Not matching
```