### PR TITLE
Add fail-fast: false to matrix tests

### DIFF
--- a/.github/workflows/python_ci.yaml
+++ b/.github/workflows/python_ci.yaml
@@ -29,6 +29,7 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ '3.10.x', '3.11.x', '3.12.x' ]
         test:


### PR DESCRIPTION
Before, all matrix tests would be stopped as soon as one of them fails:

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/d83424be-56dd-45f2-9e37-18abc90335a6)

With this change, they should keep running and all fail individually. Which should be easier to debug as one will see all the failed test right away, instead of fixing them one by one.