### PR TITLE
Revert "Make CI faster by running tests in parallel (#448)"

### DIFF
--- a/.github/workflows/python_ci.yaml
+++ b/.github/workflows/python_ci.yaml
@@ -34,14 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ '3.10.x', '3.11.x', '3.12.x' ]
-        test:
-          - name: Unit Tests
-            command: 'poetry run python -m pytest tests/ -p no:ape_test'
-          - name: Integration Tests
-            command: 'poetry run python -m pytest tests_integration/ -p no:ape_test'
-          - name: Integration with Local Chain
-            command: 'poetry run python -m pytest tests_integration_with_local_chain/ --disable-isolation'
-    name: pytest - Python ${{ matrix.python-version }} - ${{ matrix.test.name }}
+    name: pytest - Python ${{ matrix.python-version }} 
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/python_prepare
@@ -51,8 +44,12 @@ jobs:
         uses: ./.github/actions/gcp_prepare
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - name: Run Tests - ${{ matrix.test.name }}
-        run: ${{ matrix.test.command }}
+      - name: Run pytest unit tests
+        run: poetry run python -m pytest tests/ -p no:ape_test
+      - name: Run pytest integration tests
+        run: poetry run python -m pytest tests_integration/ -p no:ape_test
+      - name: Run pytest local chain integration tests
+        run: poetry run python -m pytest tests_integration_with_local_chain/ --disable-isolation
 
   black:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This reverts commit c7c84dd646e0b35bd845b82cbe0afd1f1385fb63.

Noticed that local chain test `tests_integration_with_local_chain/markets/omen/test_omen.py::test_place_bet_with_autodeposit` is failing in CI, but not locally
- https://github.com/gnosis/prediction-market-agent-tooling/actions/runs/11165099447/job/31037723237?pr=463
- https://github.com/gnosis/prediction-market-agent-tooling/actions/runs/11165303670/job/31038045952?pr=456

Testing to see if parallelisation makes a difference