### PR TITLE
Allow for different configurations of DeployablePredictionAgent.same_market_trade_interval

### DIFF
--- a/prediction_market_agent_tooling/deploy/agent.py
+++ b/prediction_market_agent_tooling/deploy/agent.py
@@ -30,6 +30,10 @@ from prediction_market_agent_tooling.deploy.gcp.utils import (
     gcp_function_is_active,
     gcp_resolve_api_keys_secrets,
 )
+from prediction_market_agent_tooling.deploy.trade_interval import (
+    FixedInterval,
+    TradeInterval,
+)
 from prediction_market_agent_tooling.gtypes import xDai, xdai_type
 from prediction_market_agent_tooling.loggers import logger
 from prediction_market_agent_tooling.markets.agent_market import (
@@ -281,7 +285,7 @@ class DeployablePredictionAgent(DeployableAgent):
     bet_on_n_markets_per_run: int = 1
     min_balance_to_keep_in_native_currency: xDai | None = xdai_type(0.1)
     allow_invalid_questions: bool = False
-    same_market_bet_interval: timedelta = timedelta(hours=24)
+    same_market_trade_interval: TradeInterval = FixedInterval(timedelta(hours=24))
     # Only Metaculus allows to post predictions without trading (buying/selling of outcome tokens).
     supported_markets: t.Sequence[MarketType] = [MarketType.METACULUS]
 
@@ -345,7 +349,9 @@ class DeployablePredictionAgent(DeployableAgent):
         Subclasses can implement their own logic instead of this one, or on top of this one.
         By default, it allows only markets where user didn't bet recently and it's a reasonable question.
         """
-        if self.have_bet_on_market_since(market, since=self.same_market_bet_interval):
+        if self.have_bet_on_market_since(
+            market, since=self.same_market_trade_interval.get(market=market)
+        ):
             return False
 
         # Manifold allows to bet only on markets with probability between 1 and 99.

--- a/prediction_market_agent_tooling/deploy/trade_interval.py
+++ b/prediction_market_agent_tooling/deploy/trade_interval.py
@@ -1,0 +1,43 @@
+from abc import ABC, abstractmethod
+from datetime import timedelta
+
+from prediction_market_agent_tooling.markets.agent_market import AgentMarket
+
+
+class TradeInterval(ABC):
+    @abstractmethod
+    def get(
+        self,
+        market: AgentMarket,
+    ) -> timedelta:
+        raise NotImplementedError("Subclass should implement this.")
+
+
+class FixedInterval(TradeInterval):
+    """
+    For trades at a fixed interval.
+    """
+
+    def __init__(self, interval: timedelta):
+        self.interval = interval
+
+    def get(
+        self,
+        market: AgentMarket,
+    ) -> timedelta:
+        return self.interval
+
+
+class MarketLifetimeProportionalInterval(TradeInterval):
+    """
+    For uniformly distributed trades over the market's lifetime.
+    """
+
+    def __init__(self, max_trades: int):
+        self.max_trades = max_trades
+
+    def get(
+        self,
+        market: AgentMarket,
+    ) -> timedelta:
+        return (market.close_time - market.created_time) / self.max_trades

--- a/prediction_market_agent_tooling/deploy/trade_interval.py
+++ b/prediction_market_agent_tooling/deploy/trade_interval.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from datetime import timedelta
 
 from prediction_market_agent_tooling.markets.agent_market import AgentMarket
+from prediction_market_agent_tooling.tools.utils import check_not_none
 
 
 class TradeInterval(ABC):
@@ -40,4 +41,6 @@ class MarketLifetimeProportionalInterval(TradeInterval):
         self,
         market: AgentMarket,
     ) -> timedelta:
-        return (market.close_time - market.created_time) / self.max_trades
+        created_time = check_not_none(market.created_time)
+        close_time = check_not_none(market.close_time)
+        return (close_time - created_time) / self.max_trades

--- a/prediction_market_agent_tooling/markets/agent_market.py
+++ b/prediction_market_agent_tooling/markets/agent_market.py
@@ -352,6 +352,3 @@ class AgentMarket(BaseModel):
 
     def get_most_recent_trade_datetime(self, user_id: str) -> DatetimeUTC | None:
         raise NotImplementedError("Subclasses must implement this method")
-
-    def uniform_betting_interval(self, num_trades: int) -> timedelta:
-        return timedelta((self.close_time - self.created_time) / num_trades)

--- a/prediction_market_agent_tooling/markets/agent_market.py
+++ b/prediction_market_agent_tooling/markets/agent_market.py
@@ -1,5 +1,4 @@
 import typing as t
-from datetime import timedelta
 from enum import Enum
 
 from eth_typing import ChecksumAddress

--- a/prediction_market_agent_tooling/markets/agent_market.py
+++ b/prediction_market_agent_tooling/markets/agent_market.py
@@ -1,4 +1,5 @@
 import typing as t
+from datetime import timedelta
 from enum import Enum
 
 from eth_typing import ChecksumAddress
@@ -351,3 +352,6 @@ class AgentMarket(BaseModel):
 
     def get_most_recent_trade_datetime(self, user_id: str) -> DatetimeUTC | None:
         raise NotImplementedError("Subclasses must implement this method")
+
+    def uniform_betting_interval(self, num_trades: int) -> timedelta:
+        return timedelta((self.close_time - self.created_time) / num_trades)

--- a/tests/test_trade_interval.py
+++ b/tests/test_trade_interval.py
@@ -19,14 +19,14 @@ def mock_market() -> Mock:
     return mock_market
 
 
-def test_fixed_interval(mock_market: Mock):
+def test_fixed_interval(mock_market: Mock) -> None:
     interval = timedelta(days=1)
     fixed_interval = FixedInterval(interval=interval)
 
     assert fixed_interval.get(mock_market) == interval
 
 
-def test_market_lifetime_proportional_interval(mock_market: Mock):
+def test_market_lifetime_proportional_interval(mock_market: Mock) -> None:
     proportional_interval = MarketLifetimeProportionalInterval(max_trades=5)
 
     assert proportional_interval.get(mock_market) == timedelta(days=2)

--- a/tests/test_trade_interval.py
+++ b/tests/test_trade_interval.py
@@ -1,0 +1,32 @@
+from datetime import timedelta
+from unittest.mock import Mock
+
+import pytest
+
+from prediction_market_agent_tooling.deploy.trade_interval import (
+    FixedInterval,
+    MarketLifetimeProportionalInterval,
+)
+from prediction_market_agent_tooling.markets.agent_market import AgentMarket
+from prediction_market_agent_tooling.tools.utils import utcnow
+
+
+@pytest.fixture
+def mock_market() -> Mock:
+    mock_market = Mock(AgentMarket, wraps=AgentMarket)
+    mock_market.created_time = utcnow()
+    mock_market.close_time = mock_market.created_time + timedelta(days=10)
+    return mock_market
+
+
+def test_fixed_interval(mock_market: Mock):
+    interval = timedelta(days=1)
+    fixed_interval = FixedInterval(interval=interval)
+
+    assert fixed_interval.get(mock_market) == interval
+
+
+def test_market_lifetime_proportional_interval(mock_market: Mock):
+    proportional_interval = MarketLifetimeProportionalInterval(max_trades=5)
+
+    assert proportional_interval.get(mock_market) == timedelta(days=2)


### PR DESCRIPTION
`DeployablePredictionAgent.same_market_trade_interval` is now an instance of a subclass of `TradeInterval`. Can define fixed intervals (default behaviour unchanged from before), or dynamic intervals based on market length.

This is another feature that is required for us to be able to scale the number of markets an agent can look at in a single run - in this case so that it doesn't bet too frequently on long-running markets.