### PR TITLE
Increase MAX_AVAILABLE_MARKETS to consider more markets

### DIFF
--- a/prediction_market_agent_tooling/deploy/agent.py
+++ b/prediction_market_agent_tooling/deploy/agent.py
@@ -430,6 +430,7 @@ class DeployablePredictionAgent(DeployableAgent):
             logger.info(f"Market '{market.question}' doesn't meet the criteria.")
             answer = None
         else:
+            logger.info(f"Answering market '{market.question}'.")
             answer = self.answer_binary_market(market)
 
         processed_market = (

--- a/prediction_market_agent_tooling/deploy/agent.py
+++ b/prediction_market_agent_tooling/deploy/agent.py
@@ -64,7 +64,7 @@ from prediction_market_agent_tooling.tools.is_predictable import is_predictable_
 from prediction_market_agent_tooling.tools.langfuse_ import langfuse_context, observe
 from prediction_market_agent_tooling.tools.utils import DatetimeUTC, utcnow
 
-MAX_AVAILABLE_MARKETS = 20
+MAX_AVAILABLE_MARKETS = 1000
 
 
 def initialize_langfuse(enable_langfuse: bool) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prediction-market-agent-tooling"
-version = "0.58.3"
+version = "0.58.4"
 description = "Tools to benchmark, deploy and monitor prediction market agents."
 authors = ["Gnosis"]
 readme = "README.md"


### PR DESCRIPTION
Currently, we ask some agents to bet on 20 markets per run. However, because we fetch only 20 markets to consider, most of them are skipped, because there is already a bet from the previous 24 hours!

So, for example `DeployablePredictionProphetGPT4oAgent`, instead of betting on around 240 markets per day, it processes only 76.

This limit on fetched markets was previously used, because in the old implementation, agent would first filter out predictable markets, and then place bets on subset of them. So verifying 1000 markets would be inefficient, but now as the agent is doing it on-the-go, it should be OK.

Instead of having huge number of fetched markets, we could paginate in batches and fetch next batch only if needed. But that needs some serious refactor. @coderabbitai Please create an issue for that.