### PR TITLE
Added order status error fallback to pools

### DIFF
--- a/prediction_market_agent_tooling/markets/seer/seer.py
+++ b/prediction_market_agent_tooling/markets/seer/seer.py
@@ -68,6 +68,7 @@ from prediction_market_agent_tooling.tools.contract import (
 )
 from prediction_market_agent_tooling.tools.cow.cow_order import (
     NoLiquidityAvailableOnCowException,
+    OrderStatusError,
     get_orders_by_owner,
     get_trades_by_order_uid,
     get_trades_by_owner,
@@ -533,6 +534,7 @@ class SeerAgentMarket(AgentMarket):
             UnexpectedResponseError,
             TimeoutError,
             NoLiquidityAvailableOnCowException,
+            OrderStatusError,
         ) as e:
             # We don't retry if not enough balance.
             if "InsufficientBalance" in str(e):


### PR DESCRIPTION
When order waiting fails OrderStatusException is thrown. This should be handled by pools fallback. 
https://github.com/gnosis/prediction-market-agent-tooling/issues/775