### PR TITLE
CategoricalKelly + fixes

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 python_version = 3.10
-files = prediction_market_agent_tooling/, tests/, tests_integration/, tests_integration_with_local_chain/, examples/, scripts/
+files = prediction_market_agent_tooling/, tests/, tests_integration/, tests_integration_with_local_chain/, scripts/
 plugins = pydantic.mypy
 warn_redundant_casts = True
 warn_unused_ignores = True

--- a/prediction_market_agent_tooling/deploy/agent.py
+++ b/prediction_market_agent_tooling/deploy/agent.py
@@ -11,7 +11,7 @@ from pydantic_ai.exceptions import UnexpectedModelBehavior
 from prediction_market_agent_tooling.config import APIKeys
 from prediction_market_agent_tooling.deploy.betting_strategy import (
     BettingStrategy,
-    MultiCategoricalMaxAccuracyBettingStrategy,
+    CategoricalMaxAccuracyBettingStrategy,
     TradeType,
 )
 from prediction_market_agent_tooling.deploy.trade_interval import (
@@ -662,9 +662,7 @@ class DeployableTraderAgent(DeployablePredictionAgent):
         Given the market and prediction, agent uses this method to calculate optimal outcome and bet size.
         """
         total_amount = self.get_total_amount_to_bet(market)
-        return MultiCategoricalMaxAccuracyBettingStrategy(
-            max_position_amount=total_amount
-        )
+        return CategoricalMaxAccuracyBettingStrategy(max_position_amount=total_amount)
 
     def build_trades(
         self,

--- a/prediction_market_agent_tooling/deploy/betting_strategy.py
+++ b/prediction_market_agent_tooling/deploy/betting_strategy.py
@@ -30,8 +30,13 @@ from prediction_market_agent_tooling.markets.omen.omen import (
 from prediction_market_agent_tooling.tools.betting_strategies.kelly_criterion import (
     get_kelly_bet_full,
     get_kelly_bet_simplified,
+    get_kelly_bets_categorical_full,
+    get_kelly_bets_categorical_simplified,
 )
-from prediction_market_agent_tooling.tools.betting_strategies.utils import SimpleBet
+from prediction_market_agent_tooling.tools.betting_strategies.utils import (
+    BinaryKellyBet,
+    CategoricalKellyBet,
+)
 from prediction_market_agent_tooling.tools.utils import check_not_none
 
 
@@ -245,7 +250,7 @@ class BettingStrategy(ABC):
         return trades
 
 
-class MultiCategoricalMaxAccuracyBettingStrategy(BettingStrategy):
+class CategoricalMaxAccuracyBettingStrategy(BettingStrategy):
     def __init__(self, max_position_amount: USD, take_profit: bool = True):
         super().__init__(take_profit=take_profit)
         self.max_position_amount = max_position_amount
@@ -308,8 +313,11 @@ class MultiCategoricalMaxAccuracyBettingStrategy(BettingStrategy):
         )
         return trades
 
+    def __repr__(self) -> str:
+        return f"CategoricalMaxAccuracyBettingStrategy(max_position_amount={self.max_position_amount}, take_profit={self.take_profit})"
 
-class MaxExpectedValueBettingStrategy(MultiCategoricalMaxAccuracyBettingStrategy):
+
+class MaxExpectedValueBettingStrategy(CategoricalMaxAccuracyBettingStrategy):
     @staticmethod
     def calculate_direction(
         market: AgentMarket, answer: CategoricalProbabilisticAnswer
@@ -350,42 +358,45 @@ class MaxExpectedValueBettingStrategy(MultiCategoricalMaxAccuracyBettingStrategy
 
         return best_outcome
 
+    def __repr__(self) -> str:
+        return f"MaxExpectedValueBettingStrategy(max_position_amount={self.max_position_amount}, take_profit={self.take_profit})"
 
-class KellyBettingStrategy(BettingStrategy):
+
+class BinaryKellyBettingStrategy(BettingStrategy):
     def __init__(
         self,
         max_position_amount: USD,
         max_price_impact: float | None = None,
         take_profit: bool = True,
+        force_simplified_calculation: bool = False,
     ):
         super().__init__(take_profit=take_profit)
         self.max_position_amount = max_position_amount
         self.max_price_impact = max_price_impact
+        self.force_simplified_calculation = force_simplified_calculation
 
     @property
     def maximum_possible_bet_amount(self) -> USD:
         return self.max_position_amount
 
-    @staticmethod
     def get_kelly_bet(
+        self,
         market: AgentMarket,
-        max_bet_amount: USD,
         direction: OutcomeStr,
         other_direction: OutcomeStr,
         answer: CategoricalProbabilisticAnswer,
         override_p_yes: float | None = None,
-    ) -> SimpleBet:
+    ) -> BinaryKellyBet:
         estimated_p_yes = (
             answer.probability_for_market_outcome(direction)
             if not override_p_yes
             else override_p_yes
         )
 
-        if not market.is_binary:
+        if market.outcome_token_pool is None or self.force_simplified_calculation:
             # use Kelly simple, since Kelly full only supports 2 outcomes
-
             kelly_bet = get_kelly_bet_simplified(
-                max_bet=market.get_usd_in_token(max_bet_amount),
+                max_bet=market.get_usd_in_token(self.max_position_amount),
                 market_p_yes=market.probability_for_market_outcome(direction),
                 estimated_p_yes=estimated_p_yes,
                 confidence=answer.confidence,
@@ -403,7 +414,7 @@ class KellyBettingStrategy(BettingStrategy):
                 yes_outcome_pool_size=direction_to_bet_pool_size,
                 no_outcome_pool_size=other_direction_pool_size,
                 estimated_p_yes=estimated_p_yes,
-                max_bet=market.get_usd_in_token(max_bet_amount),
+                max_bet=market.get_usd_in_token(self.max_position_amount),
                 confidence=answer.confidence,
                 fees=market.fees,
             )
@@ -416,7 +427,7 @@ class KellyBettingStrategy(BettingStrategy):
         market: AgentMarket,
     ) -> list[Trade]:
         # We consider the p_yes as the direction with highest probability.
-        direction = MultiCategoricalMaxAccuracyBettingStrategy.calculate_direction(
+        direction = CategoricalMaxAccuracyBettingStrategy.calculate_direction(
             market, answer
         )
         # We get the first direction which is != direction.
@@ -426,7 +437,6 @@ class KellyBettingStrategy(BettingStrategy):
 
         kelly_bet = self.get_kelly_bet(
             market=market,
-            max_bet_amount=self.max_position_amount,
             direction=direction,
             other_direction=other_direction,
             answer=answer,
@@ -472,7 +482,7 @@ class KellyBettingStrategy(BettingStrategy):
         return price_impact
 
     def calculate_bet_amount_for_price_impact(
-        self, market: AgentMarket, kelly_bet: SimpleBet, direction: OutcomeStr
+        self, market: AgentMarket, kelly_bet: BinaryKellyBet, direction: OutcomeStr
     ) -> CollateralToken:
         def calculate_price_impact_deviation_from_target_price_impact(
             bet_amount_collateral: float,  # Needs to be float because it's used in minimize_scalar internally.
@@ -510,7 +520,7 @@ class KellyBettingStrategy(BettingStrategy):
         return CollateralToken(optimized_bet_amount.x)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(max_bet_amount={self.max_position_amount}, max_price_impact={self.max_price_impact})"
+        return f"{self.__class__.__name__}(max_position_amount={self.max_position_amount}, max_price_impact={self.max_price_impact}), take_profit={self.take_profit}, force_simplified_calculation={self.force_simplified_calculation})"
 
 
 class MaxAccuracyWithKellyScaledBetsStrategy(BettingStrategy):
@@ -526,40 +536,29 @@ class MaxAccuracyWithKellyScaledBetsStrategy(BettingStrategy):
     def maximum_possible_bet_amount(self) -> USD:
         return self.max_position_amount
 
-    def adjust_bet_amount(
-        self, existing_position: ExistingPosition | None, market: AgentMarket
-    ) -> USD:
-        existing_position_total_amount = (
-            existing_position.total_amount_current if existing_position else USD(0)
-        )
-        return self.max_position_amount + existing_position_total_amount
-
     def calculate_trades(
         self,
         existing_position: ExistingPosition | None,
         answer: CategoricalProbabilisticAnswer,
         market: AgentMarket,
     ) -> list[Trade]:
-        adjusted_bet_amount_usd = self.adjust_bet_amount(existing_position, market)
-
         outcome = get_most_probable_outcome(answer.probabilities)
 
-        direction = MultiCategoricalMaxAccuracyBettingStrategy.calculate_direction(
+        direction = CategoricalMaxAccuracyBettingStrategy.calculate_direction(
             market, answer
         )
         # We get the first direction which is != direction.
-        other_direction = (
-            MultiCategoricalMaxAccuracyBettingStrategy.get_other_direction(
-                outcomes=market.outcomes, direction=direction
-            )
+        other_direction = CategoricalMaxAccuracyBettingStrategy.get_other_direction(
+            outcomes=market.outcomes, direction=direction
         )
 
         # We ignore the direction nudge given by Kelly, hence we assume we have a perfect prediction.
         estimated_p_yes = 1.0
 
-        kelly_bet = KellyBettingStrategy.get_kelly_bet(
+        kelly_bet = BinaryKellyBettingStrategy(
+            max_position_amount=self.max_position_amount
+        ).get_kelly_bet(
             market=market,
-            max_bet_amount=adjusted_bet_amount_usd,
             direction=direction,
             other_direction=other_direction,
             answer=answer,
@@ -581,4 +580,91 @@ class MaxAccuracyWithKellyScaledBetsStrategy(BettingStrategy):
         return trades
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(max_bet_amount={self.max_position_amount})"
+        return f"{self.__class__.__name__}(max_position_amount={self.max_position_amount}, take_profit={self.take_profit})"
+
+
+class CategoricalKellyBettingStrategy(BettingStrategy):
+    def __init__(
+        self,
+        max_position_amount: USD,
+        take_profit: bool = True,
+        force_simplified_calculation: bool = False,
+    ):
+        super().__init__(take_profit=take_profit)
+        self.max_position_amount = max_position_amount
+        self.force_simplified_calculation = force_simplified_calculation
+
+    @property
+    def maximum_possible_bet_amount(self) -> USD:
+        return self.max_position_amount
+
+    def get_kelly_bets(
+        self,
+        market: AgentMarket,
+        max_bet_amount: USD,
+        answer: CategoricalProbabilisticAnswer,
+    ) -> list[CategoricalKellyBet]:
+        max_bet = market.get_usd_in_token(max_bet_amount)
+
+        if market.outcome_token_pool is None or self.force_simplified_calculation:
+            kelly_bets = get_kelly_bets_categorical_simplified(
+                market_probabilities=[market.probabilities[o] for o in market.outcomes],
+                estimated_probabilities=[
+                    answer.probability_for_market_outcome(o) for o in market.outcomes
+                ],
+                confidence=answer.confidence,
+                max_bet=max_bet,
+                fees=market.fees,
+            )
+
+        else:
+            kelly_bets = get_kelly_bets_categorical_full(
+                outcome_pool_sizes=[
+                    market.outcome_token_pool[o] for o in market.outcomes
+                ],
+                estimated_probabilities=[
+                    answer.probability_for_market_outcome(o) for o in market.outcomes
+                ],
+                confidence=answer.confidence,
+                max_bet=max_bet,
+                fees=market.fees,
+            )
+
+        return kelly_bets
+
+    def calculate_trades(
+        self,
+        existing_position: ExistingPosition | None,
+        answer: CategoricalProbabilisticAnswer,
+        market: AgentMarket,
+    ) -> list[Trade]:
+        kelly_bets = self.get_kelly_bets(
+            market=market,
+            max_bet_amount=self.max_position_amount,
+            answer=answer,
+        )
+
+        # TODO: Allow shorting in BettingStrategy._build_rebalance_trades_from_positions.
+        # In binary implementation, we simply flip the direction in case of negative bet, for categorical outcome, we need to implement shorting.
+        kelly_bets = [bet for bet in kelly_bets if bet.size > 0]
+        if not kelly_bets:
+            return []
+
+        # TODO: Allow betting on multiple outcomes.
+        # Categorical kelly could suggest to bet on multiple outcomes, but we only consider the first one for now (limitation of BettingStrategy `trades` creation).
+        # Also, this could maybe work for multi-categorical markets as well, but it wasn't benchmarked for it.
+        best_kelly_bet = max(kelly_bets, key=lambda x: x.size)
+        amounts = {
+            market.outcomes[best_kelly_bet.index]: market.get_token_in_usd(
+                best_kelly_bet.size
+            ),
+        }
+        target_position = Position(market_id=market.id, amounts_current=amounts)
+        trades = self._build_rebalance_trades_from_positions(
+            existing_position, target_position, market=market
+        )
+
+        return trades
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(max_position_amount={self.max_position_amount}, take_profit={self.take_profit}, force_simplified_calculation={self.force_simplified_calculation})"

--- a/prediction_market_agent_tooling/jobs/omen/omen_jobs.py
+++ b/prediction_market_agent_tooling/jobs/omen/omen_jobs.py
@@ -2,7 +2,7 @@ import typing as t
 
 from prediction_market_agent_tooling.config import APIKeys
 from prediction_market_agent_tooling.deploy.betting_strategy import (
-    KellyBettingStrategy,
+    BinaryKellyBettingStrategy,
     TradeType,
 )
 from prediction_market_agent_tooling.gtypes import USD
@@ -93,7 +93,7 @@ class OmenJobAgentMarket(OmenAgentMarket, JobAgentMarket):
 
     def get_job_trade(self, max_bond: USD, result: str) -> Trade:
         # Because jobs are powered by prediction markets, potentional reward depends on job's liquidity and our will to bond (bet) our xDai into our job completion.
-        strategy = KellyBettingStrategy(max_position_amount=max_bond)
+        strategy = BinaryKellyBettingStrategy(max_position_amount=max_bond)
         required_trades = strategy.calculate_trades(
             existing_position=None,
             answer=self.get_job_answer(result),

--- a/prediction_market_agent_tooling/tools/betting_strategies/utils.py
+++ b/prediction_market_agent_tooling/tools/betting_strategies/utils.py
@@ -3,6 +3,11 @@ from pydantic import BaseModel
 from prediction_market_agent_tooling.gtypes import CollateralToken
 
 
-class SimpleBet(BaseModel):
+class BinaryKellyBet(BaseModel):
     direction: bool
+    size: CollateralToken
+
+
+class CategoricalKellyBet(BaseModel):
+    index: int
     size: CollateralToken

--- a/tests/test_betting_strategy.py
+++ b/tests/test_betting_strategy.py
@@ -6,8 +6,8 @@ from web3 import Web3
 
 from prediction_market_agent_tooling.deploy.betting_strategy import (
     BettingStrategy,
+    CategoricalMaxAccuracyBettingStrategy,
     GuaranteedLossError,
-    MultiCategoricalMaxAccuracyBettingStrategy,
 )
 from prediction_market_agent_tooling.gtypes import (
     USD,
@@ -51,7 +51,7 @@ from prediction_market_agent_tooling.tools.utils import utcnow
 def test_answer_decision(
     prob_multi: dict[OutcomeStr, Probability], expected_direction: OutcomeStr
 ) -> None:
-    betting_strategy = MultiCategoricalMaxAccuracyBettingStrategy(
+    betting_strategy = CategoricalMaxAccuracyBettingStrategy(
         max_position_amount=USD(0.1)
     )
     mock_answer = CategoricalProbabilisticAnswer(
@@ -97,7 +97,7 @@ def test_rebalance(take_profit: bool) -> None:
     )
     buy_token_amount = OutcomeToken(10)
     bet_amount = USD(tiny_amount.value) + mock_existing_position.total_amount_current
-    strategy = MultiCategoricalMaxAccuracyBettingStrategy(
+    strategy = CategoricalMaxAccuracyBettingStrategy(
         max_position_amount=bet_amount,
         take_profit=take_profit,
     )
@@ -158,7 +158,7 @@ def test_rebalance_with_higher_position_worth(take_profit: bool) -> None:
     buy_token_amount = OutcomeToken(10)
     # Divide the existing position two, to simulate that the existing position increased in value.
     max_position_amount = mock_existing_position.total_amount_current / 2
-    strategy = MultiCategoricalMaxAccuracyBettingStrategy(
+    strategy = CategoricalMaxAccuracyBettingStrategy(
         max_position_amount=max_position_amount,
         take_profit=take_profit,
     )
@@ -197,7 +197,7 @@ def test_rebalance_with_higher_position_worth(take_profit: bool) -> None:
     "strategy, liquidity, bet_proportion_fee, should_have_trades, should_raise, disable_cap_to_profitable_position",
     [
         (
-            MultiCategoricalMaxAccuracyBettingStrategy(max_position_amount=USD(100)),
+            CategoricalMaxAccuracyBettingStrategy(max_position_amount=USD(100)),
             1,
             0.02,
             True,
@@ -205,7 +205,7 @@ def test_rebalance_with_higher_position_worth(take_profit: bool) -> None:
             True,  # We need to disabled the profit capping in order to raise.
         ),
         (
-            MultiCategoricalMaxAccuracyBettingStrategy(max_position_amount=USD(100)),
+            CategoricalMaxAccuracyBettingStrategy(max_position_amount=USD(100)),
             1,
             0.02,
             True,
@@ -213,7 +213,7 @@ def test_rebalance_with_higher_position_worth(take_profit: bool) -> None:
             False,
         ),
         (
-            MultiCategoricalMaxAccuracyBettingStrategy(max_position_amount=USD(100)),
+            CategoricalMaxAccuracyBettingStrategy(max_position_amount=USD(100)),
             10,
             0.02,
             True,
@@ -221,7 +221,7 @@ def test_rebalance_with_higher_position_worth(take_profit: bool) -> None:
             False,
         ),
         (
-            MultiCategoricalMaxAccuracyBettingStrategy(max_position_amount=USD(100)),
+            CategoricalMaxAccuracyBettingStrategy(max_position_amount=USD(100)),
             10,
             0.5,
             True,
@@ -229,7 +229,7 @@ def test_rebalance_with_higher_position_worth(take_profit: bool) -> None:
             True,  # We need to disabled the profit capping in order to raise.
         ),
         (
-            MultiCategoricalMaxAccuracyBettingStrategy(max_position_amount=USD(100)),
+            CategoricalMaxAccuracyBettingStrategy(max_position_amount=USD(100)),
             10,
             0.5,
             False,  # Won't have trades, because the betting strategy won't do any if they aren't profitable.
@@ -239,7 +239,7 @@ def test_rebalance_with_higher_position_worth(take_profit: bool) -> None:
     ],
 )
 def test_attacking_market(
-    strategy: MultiCategoricalMaxAccuracyBettingStrategy,
+    strategy: CategoricalMaxAccuracyBettingStrategy,
     liquidity: int,
     bet_proportion_fee: float,
     should_have_trades: bool,

--- a/tests/tools/betting_strategies/test_kelly.py
+++ b/tests/tools/betting_strategies/test_kelly.py
@@ -1,0 +1,170 @@
+from prediction_market_agent_tooling.gtypes import CollateralToken, OutcomeToken
+from prediction_market_agent_tooling.markets.market_fees import MarketFees
+from prediction_market_agent_tooling.tools.betting_strategies.kelly_criterion import (
+    get_kelly_bet_full,
+    get_kelly_bet_simplified,
+    get_kelly_bets_categorical_full,
+    get_kelly_bets_categorical_simplified,
+)
+
+
+def test_kelly_simplified_underpriced() -> None:
+    # Market says 0.4, we think 0.7 (underpriced, should buy)
+    bet = get_kelly_bet_simplified(
+        max_bet=CollateralToken(100),
+        market_p_yes=0.4,
+        estimated_p_yes=0.7,
+        confidence=1.0,
+    )
+    assert bet.direction is True
+    assert bet.size.value > 0
+
+
+def test_kelly_simplified_fair_price() -> None:
+    # Market and estimate match, bet size should be near zero
+    bet = get_kelly_bet_simplified(
+        max_bet=CollateralToken(100),
+        market_p_yes=0.5,
+        estimated_p_yes=0.5,
+        confidence=1.0,
+    )
+    assert abs(bet.size.value) < 1e-6
+
+
+def test_kelly_simplified_overpriced() -> None:
+    # Market says 0.7, we think 0.4 (overpriced, should "sell" or negative bet)
+    bet = get_kelly_bet_simplified(
+        max_bet=CollateralToken(100),
+        market_p_yes=0.7,
+        estimated_p_yes=0.4,
+        confidence=1.0,
+    )
+    assert bet.direction is False
+    assert bet.size.value > 0  # bet.size is always positive, direction is False
+
+
+def test_kelly_full_underpriced() -> None:
+    # Market says 0.79, we think 0.9 (underpriced, should buy)
+    bet = get_kelly_bet_full(
+        yes_outcome_pool_size=OutcomeToken(3.598141798265440462),
+        no_outcome_pool_size=OutcomeToken(13.618140347782145810),
+        estimated_p_yes=0.9,
+        confidence=1.0,
+        max_bet=CollateralToken(100),
+        fees=MarketFees(bet_proportion=0.0, absolute=0.0),
+    )
+    assert bet.direction is True
+    assert bet.size.value > 0
+
+
+def test_kelly_full_fair_price() -> None:
+    # Market and estimate match, bet size should be near zero
+    bet = get_kelly_bet_full(
+        yes_outcome_pool_size=OutcomeToken(500),
+        no_outcome_pool_size=OutcomeToken(500),
+        estimated_p_yes=0.5,
+        confidence=1.0,
+        max_bet=CollateralToken(100),
+        fees=MarketFees(bet_proportion=0.0, absolute=0.0),
+    )
+    assert abs(bet.size.value) < 1e-6
+
+
+def test_kelly_full_overpriced() -> None:
+    # Market says 0.79, we think 0.4 (overpriced, should "sell" or negative bet)
+    bet = get_kelly_bet_full(
+        yes_outcome_pool_size=OutcomeToken(3.598141798265440462),
+        no_outcome_pool_size=OutcomeToken(13.618140347782145810),
+        estimated_p_yes=0.4,
+        confidence=1.0,
+        max_bet=CollateralToken(100),
+        fees=MarketFees(bet_proportion=0.0, absolute=0.0),
+    )
+    assert bet.direction is False
+    assert bet.size.value > 0  # bet.size is always positive, direction is False
+
+
+def test_kelly_categorical_simplified_underpriced() -> None:
+    # Market says [0.2, 0.8], we think [0.7, 0.3] (first outcome underpriced)
+    bets = get_kelly_bets_categorical_simplified(
+        market_probabilities=[0.2, 0.8],
+        estimated_probabilities=[0.7, 0.3],
+        confidence=1.0,
+        max_bet=CollateralToken(100),
+        fees=MarketFees(bet_proportion=0.0, absolute=0.0),
+    )
+    # First outcome should have positive bet (buying)
+    assert bets[0].size.value > 0
+    # Second outcome should be below zero (shorting)
+    assert bets[1].size.value < 0
+
+
+def test_kelly_categorical_simplified_fair_price() -> None:
+    # Market and estimate match, all bets should be near zero
+    bets = get_kelly_bets_categorical_simplified(
+        market_probabilities=[0.5, 0.5],
+        estimated_probabilities=[0.5, 0.5],
+        confidence=1.0,
+        max_bet=CollateralToken(100),
+        fees=MarketFees(bet_proportion=0.0, absolute=0.0),
+    )
+    assert all(abs(b.size.value) < 1e-6 for b in bets)
+
+
+def test_kelly_categorical_simplified_overpriced() -> None:
+    # Market says [0.7, 0.3], we think [0.4, 0.6] (first outcome overpriced)
+    bets = get_kelly_bets_categorical_simplified(
+        market_probabilities=[0.7, 0.3],
+        estimated_probabilities=[0.4, 0.6],
+        confidence=1.0,
+        max_bet=CollateralToken(100),
+        fees=MarketFees(bet_proportion=0.0, absolute=0.0),
+    )
+    # First outcome should be below zero (shorting)
+    assert bets[0].size.value < 0
+    # Second outcome should have positive bet (buying)
+    assert bets[1].size.value > 0
+
+
+def test_kelly_categorical_full_underpriced() -> None:
+    # Market [0.79, 0.21], we think [0.9, 0.1] (first outcome underpriced)
+    bets = get_kelly_bets_categorical_full(
+        outcome_pool_sizes=[
+            OutcomeToken(3.598141798265440462),
+            OutcomeToken(13.618140347782145810),
+        ],
+        estimated_probabilities=[0.9, 0.1],
+        confidence=1.0,
+        max_bet=CollateralToken(100),
+        fees=MarketFees(bet_proportion=0.0, absolute=0.0),
+    )
+    assert bets[0].size.value > 0, bets
+    assert bets[1].size.value < 0, bets
+
+
+def test_kelly_categorical_full_fair_price() -> None:
+    # Market pools: [500, 500], we think [0.5, 0.5] (fair)
+    bets = get_kelly_bets_categorical_full(
+        outcome_pool_sizes=[OutcomeToken(500), OutcomeToken(500)],
+        estimated_probabilities=[0.5, 0.5],
+        confidence=1.0,
+        max_bet=CollateralToken(100),
+        fees=MarketFees(bet_proportion=0.0, absolute=0.0),
+    )
+    assert all(abs(b.size.value) < 1e-6 for b in bets), bets
+
+
+def test_kelly_categorical_full_overpriced() -> None:
+    # Market [0.79, 0.20], we think [0.4, 0.6] (first outcome overpriced)
+    bets = get_kelly_bets_categorical_full(
+        outcome_pool_sizes=[
+            OutcomeToken(3.598141798265440462),
+            OutcomeToken(13.618140347782145810),
+        ],
+        estimated_probabilities=[0.4, 0.6],
+        confidence=1.0,
+        max_bet=CollateralToken(100),
+        fees=MarketFees(bet_proportion=0.0, absolute=0.0),
+    )
+    assert bets[0].size.value < 0
+    assert bets[1].size.value > 0

--- a/tests_integration/markets/omen/test_kelly.py
+++ b/tests_integration/markets/omen/test_kelly.py
@@ -1,7 +1,9 @@
 import numpy as np
 import pytest
 
-from prediction_market_agent_tooling.deploy.betting_strategy import KellyBettingStrategy
+from prediction_market_agent_tooling.deploy.betting_strategy import (
+    BinaryKellyBettingStrategy,
+)
 from prediction_market_agent_tooling.gtypes import USD, CollateralToken, OutcomeToken
 from prediction_market_agent_tooling.markets.agent_market import (
     FilterBy,
@@ -27,7 +29,7 @@ from prediction_market_agent_tooling.tools.utils import check_not_none
 
 def test_kelly_price_impact_calculation1() -> None:
     # First case from https://docs.gnosis.io/conditionaltokens/docs/introduction3/#an-example-with-cpmm
-    kelly = KellyBettingStrategy(max_position_amount=USD(1), max_price_impact=0.5)
+    kelly = BinaryKellyBettingStrategy(max_position_amount=USD(1), max_price_impact=0.5)
     yes = OutcomeToken(10)
     no = OutcomeToken(10)
     bet_amount = CollateralToken(10)
@@ -37,7 +39,7 @@ def test_kelly_price_impact_calculation1() -> None:
 
 def test_kelly_price_impact_calculation2() -> None:
     # Follow-up from first case from https://docs.gnosis.io/conditionaltokens/docs/introduction3/#an-example-with-cpmm
-    kelly = KellyBettingStrategy(max_position_amount=USD(1), max_price_impact=0.5)
+    kelly = BinaryKellyBettingStrategy(max_position_amount=USD(1), max_price_impact=0.5)
     # after first bet 10 xDAI on Yes, new yes/no
     yes = OutcomeToken(5)
     no = OutcomeToken(20)
@@ -113,7 +115,7 @@ def assert_price_impact_converges(
         fees=omen_agent_market.fees,
     )
 
-    kelly = KellyBettingStrategy(
+    kelly = BinaryKellyBettingStrategy(
         max_position_amount=max_bet_amount,
         max_price_impact=max_price_impact,
     )
@@ -143,7 +145,7 @@ def assert_price_impact(
     buy_direction: bool,
     yes: OutcomeToken,
     no: OutcomeToken,
-    kelly: KellyBettingStrategy,
+    kelly: BinaryKellyBettingStrategy,
 ) -> None:
     pool_balances = [yes.as_outcome_wei, no.as_outcome_wei]
     outcome_idx = 0 if buy_direction else 1


### PR DESCRIPTION
I'm not sure if this still should be called Kelly, but I don't have a better name, so here we go! 😄 

The goal here is to have a betting strategy that is designed for categorical markets.

Because these strategies generally "just give some number given input probs", it's hard to tell if it's "correct". What I did is:

1. Implement a few tests that test no-brainer cases: Buy if significantly underpriced, short if overpriced, do nothing if the market's probs are just right.
2. Include CategoricalKelly as one of the strategies in the betting strategy optimization script. It should be at least competitive with BinaryKelly.

After running the benchmark for `DeployablePredictionProphetGPT4oAgent`, the best strategy, acording to Optuna's `best_trial`, which is defined as `trial located at the Pareto front in the study`, is still BinaryKelly (in this experiment at least, in other runs, CategoricalKelly was winning, there is some randomness):

```
[5 / 5] Best value for DeployablePredictionProphetGPT4oAgent (params: {'strategy_name': 'BinaryKellyBettingStrategy', 'bet_amount': 24.810272693356964, 'max_price_impact': 0.9585528322007394, 'force_simplified_calculation': False}, n train bets: 931, n test bets: 157): Training maximization: [224.08885170673798, 345.7774583185099, 315.18831471615124, 275.49461200447683, 400.59789034508907] Testing profit: 338.49 Original profit on Testing: 29.77 (testing dates 2025-07-21 to 2025-07-27)
```

However, if we simply take strategies with top maximization value, `CategoricalKellyBettingStrategy (simplified)` wins and `CategoricalKellyBettingStrategy (full)` is at least not last. 

---

## DeployablePredictionProphetGPT4oAgent

1140 bets

| strategy                                     |   p_yes_mse |   total_bet_amount |   total_bet_profit |   total_simulated_amount |   total_simulated_profit |    roi |   simulated_roi |   maximize |
|:---------------------------------------------|------------:|-------------------:|-------------------:|-------------------------:|-------------------------:|-------:|----------------:|-----------:|
| CategoricalKellyBettingStrategy (simplified) |    0.196453 |             200.47 |            7.15539 |                 1111.71  |                 422.962  | 3.5693 |         38.046  |   422.962  |
| BinaryKellyBettingStrategy (full)            |    0.196453 |             200.47 |            7.15539 |                  590.521 |                 400.692  | 3.5693 |         67.854  |   400.692  |
| MaxAccuracyWithKellyScaledBetsStrategy       |    0.196453 |             200.47 |            7.15539 |                 1355.68  |                 308.301  | 3.5693 |         22.7414 |   308.301  |
| BinaryKellyBettingStrategy (simplified)      |    0.196453 |             200.47 |            7.15539 |                 1173.96  |                 216.418  | 3.5693 |         18.4348 |   216.418  |
| CategoricalKellyBettingStrategy (full)       |    0.196453 |             200.47 |            7.15539 |                  862.436 |                 140.008  | 3.5693 |         16.234  |   140.008  |
| MaxExpectedValueBettingStrategy              |    0.196453 |             200.47 |            7.15539 |                  818.023 |                 134.305  | 3.5693 |         16.4183 |   134.305  |
| CategoricalMaxAccuracyBettingStrategy        |    0.196453 |             200.47 |            7.15539 |                  517.302 |                  68.5841 | 3.5693 |         13.258  |    68.5841 |

---

A big limitation in this PR is that, while these Kelly implementations return bet sizes (including negative for shorting) across all outcomes, the `BettingStrategy` at the moment can handle only betting at one of them (the biggest one).

Follow-up PRs would be:

1. Allow the BettingStrategy class to handle multiple bets.
2. Allow shorting 