### PR TITLE
Added token pools fetching to enable kelly-bet

### DIFF
--- a/prediction_market_agent_tooling/markets/seer/price_manager.py
+++ b/prediction_market_agent_tooling/markets/seer/price_manager.py
@@ -220,7 +220,7 @@ class PriceManager:
                 )
                 probability_map[
                     OutcomeStr(model.outcomes[wrapped_tokens.index(token)])
-                ] = Probability(round(pool.token0Price, 2).value)
+                ] = Probability(pool.token0Price.value)
             else:
                 outcome_token_pool[
                     OutcomeStr(model.outcomes[wrapped_tokens.index(token)])
@@ -231,7 +231,7 @@ class PriceManager:
                 )
                 probability_map[
                     OutcomeStr(model.outcomes[wrapped_tokens.index(token)])
-                ] = Probability(round(pool.token1Price, 2).value)
+                ] = Probability(pool.token1Price.value)
 
         for outcome in model.outcomes:
             if outcome not in outcome_token_pool:

--- a/prediction_market_agent_tooling/markets/seer/price_manager.py
+++ b/prediction_market_agent_tooling/markets/seer/price_manager.py
@@ -2,6 +2,9 @@ from cachetools import TTLCache, cached
 from pydantic import BaseModel
 from web3 import Web3
 
+from prediction_market_agent_tooling.deploy.constants import (
+    INVALID_OUTCOME_LOWERCASE_IDENTIFIER,
+)
 from prediction_market_agent_tooling.gtypes import (
     ChecksumAddress,
     CollateralToken,
@@ -236,6 +239,14 @@ class PriceManager:
         for outcome in model.outcomes:
             if outcome not in outcome_token_pool:
                 outcome_token_pool[outcome] = OutcomeToken(0)
-                probability_map[outcome] = Probability(0)
-
+                logger.warning(
+                    f"Outcome {outcome} not found in outcome_token_pool for market {self.seer_market.url}."
+                )
+            if outcome not in probability_map:
+                if INVALID_OUTCOME_LOWERCASE_IDENTIFIER not in outcome.lower():
+                    raise PriceCalculationError(
+                        f"Couldn't get probability for {outcome} for market {self.seer_market.url}."
+                    )
+                else:
+                    probability_map[outcome] = Probability(0)
         return probability_map, outcome_token_pool

--- a/prediction_market_agent_tooling/markets/seer/price_manager.py
+++ b/prediction_market_agent_tooling/markets/seer/price_manager.py
@@ -7,6 +7,7 @@ from prediction_market_agent_tooling.gtypes import (
     CollateralToken,
     HexAddress,
     OutcomeStr,
+    OutcomeToken,
     Probability,
 )
 from prediction_market_agent_tooling.loggers import logger
@@ -182,3 +183,59 @@ class PriceManager:
             normalized_prices[outcome] = new_price
 
         return normalized_prices
+
+    def build_initial_probs_from_pool(
+        self, model: SeerMarket, wrapped_tokens: list[ChecksumAddress]
+    ) -> tuple[dict[OutcomeStr, Probability], dict[OutcomeStr, OutcomeToken]]:
+        """
+        Builds a map of outcome to probability and outcome token pool.
+        """
+        probability_map = {}
+        outcome_token_pool = {}
+        wrapped_tokens_with_supply = [
+            (
+                token,
+                SeerSubgraphHandler().get_pool_by_token(
+                    token, model.collateral_token_contract_address_checksummed
+                ),
+            )
+            for token in wrapped_tokens
+        ]
+        wrapped_tokens_with_supply = [
+            (token, pool)
+            for token, pool in wrapped_tokens_with_supply
+            if pool is not None
+        ]
+
+        for token, pool in wrapped_tokens_with_supply:
+            if pool is None or pool.token1.id is None or pool.token0.id is None:
+                continue
+            if HexBytes(token) == HexBytes(pool.token1.id):
+                outcome_token_pool[
+                    OutcomeStr(model.outcomes[wrapped_tokens.index(token)])
+                ] = (
+                    OutcomeToken(pool.totalValueLockedToken0)
+                    if pool.totalValueLockedToken0 is not None
+                    else OutcomeToken(0)
+                )
+                probability_map[
+                    OutcomeStr(model.outcomes[wrapped_tokens.index(token)])
+                ] = Probability(round(pool.token0Price, 2).value)
+            else:
+                outcome_token_pool[
+                    OutcomeStr(model.outcomes[wrapped_tokens.index(token)])
+                ] = (
+                    OutcomeToken(pool.totalValueLockedToken1)
+                    if pool.totalValueLockedToken1 is not None
+                    else OutcomeToken(0)
+                )
+                probability_map[
+                    OutcomeStr(model.outcomes[wrapped_tokens.index(token)])
+                ] = Probability(round(pool.token1Price, 2).value)
+
+        for outcome in model.outcomes:
+            if outcome not in outcome_token_pool:
+                outcome_token_pool[outcome] = OutcomeToken(0)
+                probability_map[outcome] = Probability(0)
+
+        return probability_map, outcome_token_pool

--- a/prediction_market_agent_tooling/markets/seer/seer.py
+++ b/prediction_market_agent_tooling/markets/seer/seer.py
@@ -411,10 +411,14 @@ class SeerAgentMarket(AgentMarket):
         must_have_prices: bool,
     ) -> t.Optional["SeerAgentMarket"]:
         price_manager = PriceManager(seer_market=model, seer_subgraph=seer_subgraph)
-
-        probability_map = {}
+        wrapped_tokens = [Web3.to_checksum_address(i) for i in model.wrapped_tokens]
         try:
-            probability_map = price_manager.build_probability_map()
+            (
+                probability_map,
+                outcome_token_pool,
+            ) = price_manager.build_initial_probs_from_pool(
+                model=model, wrapped_tokens=wrapped_tokens
+            )
         except PriceCalculationError as e:
             logger.info(
                 f"Error when calculating probabilities for market {model.id.hex()} - {e}"
@@ -437,9 +441,9 @@ class SeerAgentMarket(AgentMarket):
             condition_id=model.condition_id,
             url=model.url,
             close_time=model.close_time,
-            wrapped_tokens=[Web3.to_checksum_address(i) for i in model.wrapped_tokens],
+            wrapped_tokens=wrapped_tokens,
             fees=MarketFees.get_zero_fees(),
-            outcome_token_pool=None,
+            outcome_token_pool=outcome_token_pool,
             outcomes_supply=model.outcomes_supply,
             resolution=resolution,
             volume=None,

--- a/prediction_market_agent_tooling/markets/seer/seer_subgraph_handler.py
+++ b/prediction_market_agent_tooling/markets/seer/seer_subgraph_handler.py
@@ -352,6 +352,8 @@ class SeerSubgraphHandler(BaseSubgraphHandler):
             pools_field.token1.id,
             pools_field.token1.name,
             pools_field.token1.symbol,
+            pools_field.totalValueLockedToken0,
+            pools_field.totalValueLockedToken1,
         ]
         return fields
 

--- a/prediction_market_agent_tooling/markets/seer/subgraph_data_models.py
+++ b/prediction_market_agent_tooling/markets/seer/subgraph_data_models.py
@@ -24,6 +24,8 @@ class SeerPool(BaseModel):
     token0Price: CollateralToken
     token1Price: CollateralToken
     sqrtPrice: int
+    totalValueLockedToken0: float
+    totalValueLockedToken1: float
 
 
 class NewMarketEvent(BaseModel):


### PR DESCRIPTION
Unfortunatelly https://github.com/gnosis/prediction-market-agent-tooling/pull/813 did not worked and agents are still failing and https://github.com/gnosis/prediction-market-agent/issues/929 is not solved

After intensive testing I have found that problem is that Kelly-Bet requires outcome-token-pool values to be set see https://github.com/gnosis/prediction-market-agent-tooling/blob/286856f3b0575c1bb0be0710db946fa353e93626/prediction_market_agent_tooling/deploy/betting_strategy.py#L495

This change uses fix proposed inside of https://github.com/gnosis/prediction-market-agent-tooling/pull/794 to fill the token_pools values and fetch values from the pool instead of trying to fetch the initial values from cow. Until the cow solver is done this is probably good way to go because it shortens market loading from several minutes to ~20 sec.