### PR TITLE
Fix for low gas error for safe transactions

### DIFF
--- a/prediction_market_agent_tooling/tools/web3_utils.py
+++ b/prediction_market_agent_tooling/tools/web3_utils.py
@@ -9,6 +9,7 @@ from eth_typing import URI
 from eth_utils.currency import MAX_WEI, MIN_WEI
 from pydantic.types import SecretStr
 from safe_eth.eth import EthereumClient
+from safe_eth.eth.ethereum_client import TxSpeed
 from safe_eth.safe.safe import SafeV141
 from web3 import Web3
 from web3.constants import HASH_ZERO
@@ -269,6 +270,7 @@ def send_function_on_contract_tx_using_safe(
     tx_hash, tx = safe_tx.execute(
         from_private_key.get_secret_value(),
         tx_nonce=eoa_nonce,
+        eip1559_speed=TxSpeed.FAST,
     )
     receipt_tx = web3.eth.wait_for_transaction_receipt(tx_hash, timeout=timeout)
     check_tx_receipt(receipt_tx)


### PR DESCRIPTION
Fixes https://github.com/gnosis/prediction-market-agent-tooling/issues/810 and https://github.com/gnosis/prediction-market-agent-tooling/issues/829 - should lead to higher fees but better reliability.

    def estimate_fee_eip1559(
        self, tx_speed: TxSpeed = TxSpeed.NORMAL
    ) -> Tuple[int, int]:
        """
        Check https://github.com/ethereum/execution-apis/blob/main/src/eth/fee_market.json#L15

        :return: Tuple[BaseFeePerGas, MaxPriorityFeePerGas]
        :raises: ValueError if not supported on the network
        """
        if tx_speed == TxSpeed.SLOWEST:
            percentile = 0
        elif tx_speed == TxSpeed.VERY_SLOW:
            percentile = 10
        elif tx_speed == TxSpeed.SLOW:
            percentile = 25
        elif tx_speed == TxSpeed.NORMAL:
            percentile = 50
        elif tx_speed == TxSpeed.FAST:
            percentile = 75
        elif tx_speed == TxSpeed.VERY_FAST:
            percentile = 90
        elif tx_speed == TxSpeed.FASTEST:
            percentile = 100
        else:
            percentile = 50

        result = self.w3.eth.fee_history(1, "latest", reward_percentiles=[percentile])
        # Get next block `base_fee_per_gas`
        base_fee_per_gas = result["baseFeePerGas"][-1]
        max_priority_fee_per_gas = result["reward"][0][0]
        return base_fee_per_gas, max_priority_fee_per_gas