### PR TITLE
fix: log Polymarket events skipped for having no inner markets

### DIFF
--- a/prediction_market_agent_tooling/markets/polymarket/api.py
+++ b/prediction_market_agent_tooling/markets/polymarket/api.py
@@ -91,8 +91,14 @@ def get_polymarkets_with_pagination(
 
         markets_to_add = []
         for m in market_response.data:
-            # Some Polymarket markets are missing the markets field
-            if not m.markets or m.markets[0].clobTokenIds is None:
+            if not m.markets:
+                # Leftover events from before Polymarket grouped markets under a shared
+                # parent event: the inner markets were re-parented and are still returned
+                # under the new event, so nothing is lost by skipping this one. Logged so
+                # that we notice if events start losing their markets for another reason.
+                logger.info(f"Event {m.id} ({m.slug}) has no markets. Skipping.")
+                continue
+            if m.markets[0].clobTokenIds is None:
                 continue
             if excluded_questions and m.title in excluded_questions:
                 continue

--- a/tests/markets/polymarket/test_polymarket_api_events.py
+++ b/tests/markets/polymarket/test_polymarket_api_events.py
@@ -6,6 +6,7 @@ import tenacity
 from prediction_market_agent_tooling.markets.polymarket.api import (
     get_gamma_event_by_id,
     get_gamma_event_by_slug,
+    get_polymarkets_with_pagination,
 )
 from prediction_market_agent_tooling.markets.polymarket.data_models import (
     PolymarketGammaResponseDataItem,
@@ -81,3 +82,36 @@ def test_get_gamma_event_by_slug_empty_raises(mock_client_cls: MagicMock) -> Non
 
     with pytest.raises(tenacity.RetryError):
         get_gamma_event_by_slug("nonexistent-slug")
+
+
+@patch("prediction_market_agent_tooling.markets.polymarket.api.logger")
+@patch("prediction_market_agent_tooling.markets.polymarket.api.Client")
+def test_get_polymarkets_with_pagination_skips_event_without_markets(
+    mock_client_cls: MagicMock, mock_logger: MagicMock
+) -> None:
+    # Leftover Polymarket events (e.g. id 4871) come back without the `markets` field
+    # at all, they must be skipped instead of breaking the whole batch.
+    event_without_markets = {
+        "id": "4871",
+        "slug": "will-there-be-an-emergency-use-authorization-eua-granted-for-a-covid-19-vaccine-before-2021",
+        "title": "Will there be an EUA granted for a COVID-19 vaccine before 2021?",
+        "startDate": "2020-11-09T00:00:00Z",
+        "archived": False,
+        "closed": True,
+        "active": True,
+    }
+    event_with_markets = _mock_event_json() | {"startDate": "2025-01-01T00:00:00Z"}
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [event_without_markets, event_with_markets],
+        "pagination": {"hasMore": False},
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_response.headers = {"content-type": "application/json"}
+    mock_client_cls.return_value.get.return_value = mock_response
+
+    markets = get_polymarkets_with_pagination(limit=10)
+
+    assert [m.id for m in markets] == ["12345"]
+    mock_logger.info.assert_called_once()
+    assert "4871" in mock_logger.info.call_args.args[0]


### PR DESCRIPTION
# Investigate Polymarket events with a missing `markets` field

Fixes #950

**Up front:** the investigation is the main deliverable here. The library's existing
handling turned out to be *correct* — no markets are being lost — so the code change is
deliberately small: it records the root cause where the skip happens and makes the skip
observable, which is what the issue asks for ("we could miss some markets because of that
in the future"). If you'd rather have only the comment and not the log line, say so and I'll
trim it.

## Root cause

`markets` is genuinely absent from some Gamma event payloads — not just in
`events/pagination`, but from `/events/{id}` and `/events?slug=` too. So this is upstream
data, not a parsing or pagination problem, and the `= None` default at
`prediction_market_agent_tooling/markets/polymarket/data_models.py:119` has to stay.

Of Tomas's two theories, **#1 (old market) is the right one; #2 (a Yes/No question that
simply has no child markets) is wrong** — the child markets exist, they're just attached to
a different event.

These are leftover per-market events from 2020–2022, created before Polymarket grouped
several markets under one parent event. When the grouping was introduced the market rows
were re-parented, leaving the original event behind as an empty shell. Verified against the
live API for three of the events listed in the issue:

| empty event | its market today | market's current event |
|---|---|---|
| 5897 `ufc-277-who-will-win-pena-vs-nunes` | market 246871 | 5902 `UFC-277` (4 markets) |
| 5889 `ufc-277-who-will-win-lewis-vs-pavlovich` | market 246874 | 5902 `UFC-277` |
| 4455 `will-president-biden-declare-a-national-emergency-before-september` | market 246842 | 5881 `resowill-president-biden-...` |

Event 5902 and 5881 are both returned normally by `events/pagination` **with** their
`markets`, so `get_polymarkets_with_pagination` still sees every one of those markets. The
skip at `api.py:95` loses nothing.

The one exception is event **4871**
(`will-there-be-an-emergency-use-authorization-eua-granted-for-a-covid-19-vaccine-before-2021`,
volume 0): `GET /markets?slug=...&closed=true` returns `[]` for it, i.e. there is no market
behind it anywhere in Gamma. Nothing to recover.

I also swept all four `archived={true,false}` × `closed={true,false}` combinations of
`events/pagination`, ordered by `startDate asc`, and separately 2000 events from `/events`.
In the 8400 event records reachable today, **4871 was the only one** without `markets`.
Gamma never returned `"markets": []` — the key is always either present and non-empty, or
absent entirely.

## Fix

`prediction_market_agent_tooling/markets/polymarket/api.py:94`

The old line conflated two unrelated skip reasons behind one vague comment:

```python
# Some Polymarket markets are missing the markets field
if not m.markets or m.markets[0].clobTokenIds is None:
    continue
```

Split into the two cases, replaced the comment with the actual explanation, and added a
`logger.info` on the no-markets branch (matching `polymarket.py:164`, which already logs
`"Market has no outcome prices. Skipping."` the same way). That's the whole change — the
filtering behaviour is byte-for-byte identical.

Rationale for logging rather than "fixing": there is nothing to fix in the filter, but today
the drop is completely silent. If Polymarket's data ever changes shape and events start
losing their `markets` for a *different* reason, this is the difference between noticing and
silently returning fewer markets. Volume is negligible — 1 line per full sweep at today's
data.

## Testing

Ran with a local venv (Python 3.12, `uv pip install -e . pytest "psycopg[binary]"`) since
`poetry` isn't available in this environment; commands otherwise match `python_ci.yaml`.

New test — `tests/markets/polymarket/test_polymarket_api_events.py::test_get_polymarkets_with_pagination_skips_event_without_markets`.
It feeds a mocked pagination page containing real event 4871 (no `markets` key) plus a valid
binary event.

Before the change:

```
$ .venv/bin/python -m pytest tests/markets/polymarket/test_polymarket_api_events.py -q -p no:ape_test
E   AssertionError: Expected 'info' to have been called once. Called 0 times.
1 failed, 3 passed
```

**Be precise about what that means:** the `assert [m.id for m in markets] == ["12345"]` part
already passed before the change — the skip itself was never broken. Only the "we can see it
happened" assertion failed. I could not write a test that fails on a functional defect,
because there isn't one.

After:

```
$ .venv/bin/python -m pytest tests/markets/polymarket/test_polymarket_api_events.py -q -p no:ape_test
4 passed
```

Module suite:

```
$ .venv/bin/python -m pytest tests/markets/polymarket/ -q -p no:ape_test
6 failed, 150 passed
```

The same 6 fail on unmodified `main` in this environment (`test_polymarket_fees.py::test_get_fee_0/1`,
`test_polymarket_methods.py::TestHaveBetOnMarketSince::test_true_when_recent_trade`, and the
3 in `test_polymarket_positions.py`) — pre-existing, unrelated to this change.

Linters, on the two changed files:

```
$ .venv/bin/black --check ...                                  # unchanged
$ .venv/bin/isort --profile black --check-only ...             # clean
$ .venv/bin/autoflake --check --remove-all-unused-imports ...  # No issues detected
$ .venv/bin/mypy --python-version 3.12 ...                     # Success: no issues found in 2 source files
```

(`mypy` with the repo's `python_version = 3.10` aborts on `numpy/__init__.pyi:737` — "Type
statement is only supported in Python 3.12 and greater" — before checking anything. That's
the installed numpy version in my venv, not this diff.)

## Notes for reviewer

1. **`tests_integration/markets/polymarket/test_get_markets.py::test_many_markets` — the
   test the issue tells you to run — currently fails on `main`, for an unrelated reason.**
   Gamma has started hard-capping `events/pagination`:

   ```
   HTTP 422 {"type":"validation error",
             "error":"offset too large, use /events/keyset for deeper pagination"}
   ```

   The cap kicks in somewhere in `2000 < offset <= 2050`. `get_polymarkets_with_pagination`
   calls `r.raise_for_status()`, so tenacity retries 5× and then raises `RetryError`:

   ```
   $ get_polymarkets_with_pagination(limit=1000, closed=True,
         order_by=VOLUME_24HR, ascending=False, only_binary=True)
   ERR RetryError[<Future ... raised HTTPStatusError>]
   ```

   This *is* a real "we're missing markets" bug — everything past offset ~2050 is now
   unreachable and would need `/events/keyset` — but it's a different problem from #950, so
   I left it alone rather than bundling it in. Happy to open a separate issue/PR if useful.
   It also means I could not use `test_many_markets` to verify this change end-to-end.

2. Because of that cap, the deep-offset events from @TS9001's sweep (5897, 5889, 5890, 5898,
   4455, …) are no longer reachable via `events/pagination` at all today. I confirmed their
   payloads through `/events/{id}` and `/events?slug=` instead.

3. `logger.info` level is a judgement call — `warning` would be more visible but this is
   expected, benign upstream data, so `info` felt right and matches the neighbouring
   `"Market has no outcome prices. Skipping."` in `polymarket.py`.

4. Related inconsistency I noticed but deliberately did **not** touch, since Gamma never
   actually returns `"markets": []`: `polymarket.py:145` guards with `if model.markets is
   None`, whereas `api.py:95`, `polymarket.py:335`, `:346` and `:667` all use a falsy check.
   An empty list would slip past line 145 and `IndexError` on `model.markets[0]` at line 159.
   Purely theoretical against today's API — flagging it rather than adding speculative
   hardening.

---
This contribution was developed with AI assistance (Claude Code). I reviewed the change and the test results before submitting.